### PR TITLE
package(feat): #17 add union schema generation for tool error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "0.6.0"
+version = "0.6.1"
 
 dependencies = ["pydantic==2.12.3", "uvicorn==0.38.0", "starlette==0.49.1"]
 

--- a/src/http_mcp/types/utils.py
+++ b/src/http_mcp/types/utils.py
@@ -1,0 +1,38 @@
+from pydantic import BaseModel
+
+
+def generate_union_schema(
+    type_a: type[BaseModel],
+    type_b: type[BaseModel],
+) -> dict:
+    """Generate a JSON schema representing the union of two BaseModel types.
+
+    Args:
+        type_a: First BaseModel class
+        type_b: Second BaseModel class
+
+    Returns:
+        A JSON schema with oneOf constraint representing the union of both types
+
+    """
+    schema_a = type_a.model_json_schema(by_alias=False)
+    schema_b = type_b.model_json_schema(by_alias=False)
+
+    # Merge all definitions from both schemas
+    all_defs = {}
+    all_defs.update(schema_a.get("$defs", {}))
+    all_defs.update(schema_b.get("$defs", {}))
+
+    # Add the main types to definitions if they're not already there
+    if type_a.__name__ not in all_defs:
+        all_defs[type_a.__name__] = {k: v for k, v in schema_a.items() if k != "$defs"}
+    if type_b.__name__ not in all_defs:
+        all_defs[type_b.__name__] = {k: v for k, v in schema_b.items() if k != "$defs"}
+
+    return {
+        "$defs": all_defs,
+        "oneOf": [
+            {"$ref": f"#/$defs/{type_a.__name__}"},
+            {"$ref": f"#/$defs/{type_b.__name__}"},
+        ],
+    }

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+
+from starlette.testclient import TestClient
+
+from tests.app.main import mcp_server, mount_mcp_server
+
+
+def test_http() -> None:
+    app = mount_mcp_server(mcp_server)
+    client = TestClient(app)
+    response = client.post("/mcp", json={"jsonrpc": "2.0", "method": "tools/list", "id": 1})
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_http_list_only_public_tools() -> None:
+    app = mount_mcp_server(mcp_server)
+    client = TestClient(app)
+    response = client.post("/mcp", json={"jsonrpc": "2.0", "method": "tools/list", "id": 1})
+    assert response.status_code == HTTPStatus.OK
+    response_json = response.json()
+    assert response_json == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "title": "Get Weather",
+                    "description": "Get the current weather in a given location.",
+                    "inputSchema": {
+                        "properties": {
+                            "location": {
+                                "description": "The location to get the weather for",
+                                "title": "Location",
+                                "type": "string",
+                            },
+                            "unit": {
+                                "default": "celsius",
+                                "description": "The unit of temperature",
+                                "title": "Unit",
+                                "type": "string",
+                            },
+                        },
+                        "required": ["location"],
+                        "title": "get_weatherArguments",
+                        "type": "object",
+                    },
+                    "outputSchema": {
+                        "properties": {
+                            "weather": {
+                                "description": "The weather in the given location",
+                                "title": "Weather",
+                                "type": "string",
+                            },
+                        },
+                        "required": ["weather"],
+                        "title": "get_weatherOutput",
+                        "type": "object",
+                    },
+                    "annotations": {
+                        "title": "Get Weather",
+                        "readOnlyHint": False,
+                        "destructiveHint": False,
+                        "idempotentHint": True,
+                        "openWorldHint": True,
+                    },
+                    "meta": None,
+                },
+                {
+                    "name": "get_time",
+                    "title": "Get Time",
+                    "description": "Get the current time.",
+                    "inputSchema": {
+                        "properties": {},
+                        "title": "get_timeArguments",
+                        "type": "object",
+                    },
+                    "outputSchema": {
+                        "properties": {
+                            "time": {
+                                "description": "The current time",
+                                "title": "Time",
+                                "type": "string",
+                            },
+                        },
+                        "required": ["time"],
+                        "title": "get_timeOutput",
+                        "type": "object",
+                    },
+                    "annotations": {
+                        "title": "Get Time",
+                        "readOnlyHint": False,
+                        "destructiveHint": False,
+                        "idempotentHint": True,
+                        "openWorldHint": True,
+                    },
+                    "meta": None,
+                },
+                {
+                    "name": "tool_that_access_request",
+                    "title": "Tool That Access Request",
+                    "description": "Access the request.",
+                    "inputSchema": {
+                        "properties": {
+                            "username": {
+                                "description": "The username of the user",
+                                "title": "Username",
+                                "type": "string",
+                            },
+                        },
+                        "required": ["username"],
+                        "title": "tool_that_access_requestArguments",
+                        "type": "object",
+                    },
+                    "outputSchema": {
+                        "properties": {
+                            "message": {
+                                "description": "The message to the user",
+                                "title": "Message",
+                                "type": "string",
+                            },
+                        },
+                        "required": ["message"],
+                        "title": "tool_that_access_requestOutput",
+                        "type": "object",
+                    },
+                    "annotations": {
+                        "title": "Tool That Access Request",
+                        "readOnlyHint": False,
+                        "destructiveHint": False,
+                        "idempotentHint": True,
+                        "openWorldHint": True,
+                    },
+                    "meta": None,
+                },
+                {
+                    "name": "get_called_tools",
+                    "title": "Get Called Tools",
+                    "description": "Get the list of called tools.",
+                    "inputSchema": {
+                        "properties": {},
+                        "title": "get_called_toolsArguments",
+                        "type": "object",
+                    },
+                    "outputSchema": {
+                        "properties": {
+                            "called_tools": {
+                                "description": "The list of called tools",
+                                "items": {"type": "string"},
+                                "title": "Called Tools",
+                                "type": "array",
+                            },
+                        },
+                        "required": ["called_tools"],
+                        "title": "get_called_toolsOutput",
+                        "type": "object",
+                    },
+                    "annotations": {
+                        "title": "Get Called Tools",
+                        "readOnlyHint": False,
+                        "destructiveHint": False,
+                        "idempotentHint": True,
+                        "openWorldHint": True,
+                    },
+                    "meta": None,
+                },
+            ],
+            "nextCursor": "",
+        },
+    }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,36 +1,18 @@
 import pytest
 from jsonschema import Draft7Validator
-from jsonschema.exceptions import SchemaError
+from jsonschema.exceptions import ValidationError
 from pydantic import BaseModel, Field
 
 from http_mcp.types import Tool
-from http_mcp.types.models import InvocationResult
-
-
-def test_invocation_result_generate_json_schema() -> None:
-    class TestOutput(BaseModel):
-        answer: str
-
-    schema = InvocationResult[TestOutput].generate_json_schema(TestOutput)
-
-    class TestOutputSchema(BaseModel):
-        output: TestOutput | None
-        error_message: str | None
-
-    expected_schema = TestOutputSchema.model_json_schema(by_alias=False)
-
-    for key, value in expected_schema.items():
-        if key != "title":
-            assert schema[key] == value
 
 
 class TestOutput(BaseModel):
-    answer: str = Field(description="The answer to the question")
+    status_code: int = Field(description="The status code of the response")
     optional_answer: str | None = Field(
         default=None,
         description="The optional answer to the question",
     )
-    description: int = Field(description="The description of the answer")
+    description: str = Field(description="The description of the answer")
     title: str = Field(default="Test Output", description="The title of the answer")
     items: list[str] = Field(description="The items of the answer")
     optional_items: list[str] | None = Field(
@@ -39,26 +21,8 @@ class TestOutput(BaseModel):
     )
 
 
-class TestOutputSchema(BaseModel):
-    output: TestOutput | None
-    error_message: str | None
-
-
-def test_complex_invocation_result_generate_json_schema() -> None:
-    schema = InvocationResult[TestOutput].generate_json_schema(TestOutput)
-
-    expected_schema = TestOutputSchema.model_json_schema(by_alias=False)
-
-    for key, value in expected_schema.items():
-        if key != "title":
-            assert schema[key] == value
-
-
-def test_tool_generate_json_schema() -> None:
+def test_invocation_result_generate_union_output_json_schema() -> None:
     def tool_generate_json_schema_1() -> TestOutput:
-        raise NotImplementedError
-
-    def tool_generate_json_schema_2() -> TestOutputSchema:
         raise NotImplementedError
 
     tool_1 = Tool(
@@ -67,34 +31,28 @@ def test_tool_generate_json_schema() -> None:
         output=TestOutput,
         return_error_message=True,
     )
-    tool_2 = Tool(
-        func=tool_generate_json_schema_2,
-        inputs=type(None),
-        output=TestOutputSchema,
-        return_error_message=False,
-    )
     schema_1 = tool_1.generate_json_schema()
-    schema_2 = tool_2.generate_json_schema()
+    output_schema = schema_1["outputSchema"]
 
+    # Verify the schema itself is valid
+    Draft7Validator.check_schema(output_schema)
+
+    # Create validator with the output schema
+    validator = Draft7Validator(output_schema)
+
+    # Test that valid TestOutput data validates successfully
     test_output = TestOutput(
-        answer="test",
-        description=1,
+        status_code=200,
+        description="test",
         items=["item1", "item2"],
         optional_items=["item3", "item4"],
         optional_answer=None,
-        title="Test Output",
     )
-    return_value = TestOutputSchema(
-        output=test_output,
-        error_message=None,
-    ).model_dump()
+    validator.validate(test_output.model_dump())
 
-    validator_1 = Draft7Validator(schema_1)
-    validator_2 = Draft7Validator(schema_2)
+    # Test that valid ErrorMessage data also validates successfully
+    error_output = {"error_message": "Something went wrong"}
+    validator.validate(error_output)
 
-    validator_1.check_schema(return_value)
-    validator_2.check_schema(return_value)
-    with pytest.raises(SchemaError):
-        validator_1.check_schema(test_output.model_dump())
-    with pytest.raises(SchemaError):
-        validator_2.check_schema(test_output.model_dump())
+    with pytest.raises(ValidationError):
+        validator.validate({"error_message": 78})

--- a/tests/test_tools_methods.py
+++ b/tests/test_tools_methods.py
@@ -295,6 +295,24 @@ def test_list_tools() -> None:
                     "name": "tool_that_raises_invocation_result",
                     "outputSchema": {
                         "$defs": {
+                            "ErrorMessage": {
+                                "description": (
+                                    "Returned feedback if the tool invocation was not successful."
+                                ),
+                                "properties": {
+                                    "error_message": {
+                                        "description": (
+                                            "The error message if the tool invocation was not "
+                                            "successful"
+                                        ),
+                                        "title": "Error Message",
+                                        "type": "string",
+                                    },
+                                },
+                                "required": ["error_message"],
+                                "title": "ErrorMessage",
+                                "type": "object",
+                            },
                             "TestTool1Output": {
                                 "title": "TestTool1Output",
                                 "type": "object",
@@ -308,21 +326,11 @@ def test_list_tools() -> None:
                                 "required": ["answer"],
                             },
                         },
-                        "properties": {
-                            "output": {
-                                "anyOf": [
-                                    {"$ref": "#/$defs/TestTool1Output"},
-                                    {"type": "null"},
-                                ],
-                            },
-                            "error_message": {
-                                "anyOf": [{"type": "string"}, {"type": "null"}],
-                                "title": "Error Message",
-                            },
-                        },
-                        "required": ["output", "error_message"],
+                        "oneOf": [
+                            {"$ref": "#/$defs/TestTool1Output"},
+                            {"$ref": "#/$defs/ErrorMessage"},
+                        ],
                         "title": "tool_that_raises_invocation_resultOutput",
-                        "type": "object",
                     },
                     "title": "Tool That Raises Invocation Result",
                 },

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "http-mcp"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
- Add generate_union_schema utility function to create JSON schemas with oneOf constraints
- Refactor Tool output schema to use proper union type (oneOf) for error handling
- Update Tool.output_schema to generate union of output model and ErrorMessage
- Improve test coverage for union schema validation
- Bump version to 0.6.1

The new approach uses JSON Schema's oneOf constraint to properly represent the union of successful output and error messages, replacing the previous approach that used nullable fields. This provides better type safety and clearer schema definitions for tool invocations with error handling enabled.