### PR TITLE
package(feat): #17 authorization scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@ prompts that can be discovered and executed remotely via a JSON-RPC interface.
 It is intended to be used with a Starlette or FastAPI application (see
 [demo](https://github.com/yeison-liscano/demo_http_mcp)).
 
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Server Architecture](#server-architecture)
+- [Tools](#tools)
+  - [Basic Tool Example](#basic-tool-example)
+  - [Tools Without Arguments](#tools-without-arguments)
+  - [Tools with Error Handling](#tools-with-error-handling)
+  - [Tools with Authorization Scopes](#tools-with-authorization-scopes)
+- [Server State Management](#server-state-management)
+- [Request Access](#request-access)
+- [Prompts](#prompts)
+  - [Basic Prompt Example](#basic-prompt-example)
+  - [Prompts Without Arguments](#prompts-without-arguments)
+  - [Prompts with Lifespan State](#prompts-with-lifespan-state)
+  - [Prompts with Authorization Scopes](#prompts-with-authorization-scopes)
+- [STDIO Transport](#stdio-transport)
+- [Authentication and Authorization](#authentication-and-authorization)
+- [API Reference](#api-reference)
+- [License](#license)
+
 ## Features
 
 - **MCP Protocol Compliant**: Implements the MCP specification for tool and
@@ -20,6 +42,10 @@ It is intended to be used with a Starlette or FastAPI application (see
   using the `get_state_key` method.
 - **Request Access**: Access the incoming request object from your tools and
   prompts.
+- **Authorization Scopes**: Support for scope-based authorization using
+  Starlette's authentication system.
+- **Error Handling**: Tools can optionally return error messages instead of
+  raising exceptions.
 
 ## Server Architecture
 
@@ -39,6 +65,16 @@ managing shared server state.
   lifecycle, not per-request
 - **Flexible**: Can be used with any custom context class stored in the lifespan
   state
+
+**Constructor Parameters:**
+
+- `name` (str): The name of your MCP server
+- `version` (str): The version of your MCP server
+- `tools` (tuple[Tool, ...]): Tuple of tools to expose (default: empty tuple)
+- `prompts` (tuple[Prompt, ...]): Tuple of prompts to expose (default: empty
+  tuple)
+- `instructions` (str | None): Optional instructions for AI assistants on how to
+  use this server
 
 **Example Usage:**
 
@@ -66,7 +102,8 @@ mcp_server = MCPServer(
     name="my-server",
     version="1.0.0",
     tools=my_tools,
-    prompts=my_prompts
+    prompts=my_prompts,
+    instructions="Optional instructions for AI assistants on how to use this server"
 )
 
 app = Starlette(lifespan=lifespan)
@@ -77,7 +114,7 @@ app.mount("/mcp", mcp_server.app)
 
 Tools are the functions that can be called by the client.
 
-Example:
+### Basic Tool Example
 
 1. **Define the arguments and output for the tools:**
 
@@ -143,6 +180,128 @@ app.mount(
     mcp_server.app,
 )
 ```
+
+### Tools Without Arguments
+
+You can define tools that don't require any input arguments:
+
+```python
+from datetime import UTC, datetime
+from pydantic import BaseModel, Field
+from http_mcp.types import Tool
+
+class GetTimeOutput(BaseModel):
+    time: str = Field(description="The current time")
+
+async def get_time() -> GetTimeOutput:
+    """Get the current time."""
+    return GetTimeOutput(time=datetime.now(UTC).strftime("%H:%M:%S"))
+
+TOOLS = (
+    Tool(
+        func=get_time,
+        inputs=type(None),  # No arguments required
+        output=GetTimeOutput,
+    ),
+)
+```
+
+Alternatively, you can use the `NoArguments` class for better clarity:
+
+```python
+from http_mcp.types import Arguments, NoArguments, Tool
+
+class SimpleOutput(BaseModel):
+    success: bool = Field(description="Whether the operation was successful")
+
+def simple_tool(args: Arguments[NoArguments]) -> SimpleOutput:
+    """A simple tool with no arguments."""
+    # You can still access request and state
+    context = args.get_state_key("context", Context)
+    return SimpleOutput(success=True)
+
+TOOLS = (
+    Tool(
+        func=simple_tool,
+        inputs=NoArguments,
+        output=SimpleOutput,
+    ),
+)
+```
+
+### Tools with Error Handling
+
+Tools can optionally return error messages instead of raising exceptions:
+
+```python
+from pydantic import BaseModel, Field
+from http_mcp.types import Arguments, Tool
+from http_mcp.exceptions import ToolInvocationError
+
+class RiskyToolInput(BaseModel):
+    value: int = Field(description="An integer value")
+
+class RiskyToolOutput(BaseModel):
+    result: str = Field(description="The result of the operation")
+
+def risky_tool(args: Arguments[RiskyToolInput]) -> RiskyToolOutput:
+    """A tool that might fail."""
+    if args.inputs.value < 0:
+        raise ToolInvocationError("risky_tool", "Value must be positive")
+    return RiskyToolOutput(result=f"Success: {args.inputs.value}")
+
+TOOLS = (
+    Tool(
+        func=risky_tool,
+        inputs=RiskyToolInput,
+        output=RiskyToolOutput,
+        return_error_message=True,  # Return ErrorMessage instead of raising
+    ),
+)
+```
+
+When `return_error_message=True`, the tool will return an `ErrorMessage` model
+with the error details instead of raising a `ToolInvocationError`.
+
+### Tools with Authorization Scopes
+
+You can restrict tool access based on authentication scopes:
+
+```python
+from http_mcp.types import Arguments, NoArguments, Tool
+from starlette.authentication import has_required_scope
+
+class SecureOutput(BaseModel):
+    message: str = Field(description="A secure message")
+
+def private_tool(args: Arguments[NoArguments]) -> SecureOutput:
+    """A tool that requires authentication."""
+    assert has_required_scope(args.request, ("private",))
+    return SecureOutput(message="This is private data")
+
+def admin_tool(args: Arguments[NoArguments]) -> SecureOutput:
+    """A tool that requires admin or superuser scope."""
+    assert has_required_scope(args.request, ("admin", "superuser"))
+    return SecureOutput(message="This is admin data")
+
+TOOLS = (
+    Tool(
+        func=private_tool,
+        inputs=NoArguments,
+        output=SecureOutput,
+        scopes=("private",),  # Only accessible with 'private' scope
+    ),
+    Tool(
+        func=admin_tool,
+        inputs=NoArguments,
+        output=SecureOutput,
+        scopes=("admin", "superuser"),  # Accessible with either scope
+    ),
+)
+```
+
+Note: You need to set up authentication middleware in your Starlette app for
+scopes to work properly.
 
 ## Server State Management
 
@@ -259,6 +418,8 @@ mcp_server = MCPServer(
 You can add interactive templates that are invoked by user choice. Prompts now
 support lifespan state access, similar to tools.
 
+### Basic Prompt Example
+
 1. **Define the arguments for the prompts:**
 
 ```python
@@ -303,7 +464,78 @@ PROMPTS = (
 )
 ```
 
-2. **Using prompts with lifespan state:**
+2. **Instantiate the server:**
+
+```python
+from starlette.applications import Starlette
+
+from app.prompts import PROMPTS
+from http_mcp.server import MCPServer
+
+app = Starlette()
+mcp_server = MCPServer(tools=(), prompts=PROMPTS, name="test", version="1.0.0")
+
+app.mount(
+    "/mcp",
+    mcp_server.app,
+)
+```
+
+### Prompts Without Arguments
+
+You can define prompts that don't require any input arguments:
+
+```python
+from http_mcp.mcp_types.content import TextContent
+from http_mcp.mcp_types.prompts import PromptMessage
+from http_mcp.types import Prompt
+
+def help_prompt() -> tuple[PromptMessage, ...]:
+    """Use this prompt to get general help."""
+    return (
+        PromptMessage(
+            role="user",
+            content=TextContent(
+                text="You are a helpful assistant. Help the user with their task."
+            ),
+        ),
+    )
+
+PROMPTS = (
+    Prompt(
+        func=help_prompt,
+        arguments_type=type(None),  # No arguments required
+    ),
+)
+```
+
+Alternatively, you can use the `NoArguments` class:
+
+```python
+from http_mcp.types import Arguments, NoArguments, Prompt
+from http_mcp.mcp_types.content import TextContent
+from http_mcp.mcp_types.prompts import PromptMessage
+
+def help_prompt_with_context(args: Arguments[NoArguments]) -> tuple[PromptMessage, ...]:
+    """Use this prompt to get help with access to context."""
+    # You can still access request and state
+    context = args.get_state_key("context", Context)
+    return (
+        PromptMessage(
+            role="user",
+            content=TextContent(text="You are a helpful assistant."),
+        ),
+    )
+
+PROMPTS = (
+    Prompt(
+        func=help_prompt_with_context,
+        arguments_type=NoArguments,
+    ),
+)
+```
+
+### Prompts with Lifespan State
 
 ```python
 from pydantic import BaseModel, Field
@@ -345,19 +577,270 @@ PROMPTS_WITH_CONTEXT = (
 )
 ```
 
-3. **Instantiate the server:**
+### Prompts with Authorization Scopes
+
+You can restrict prompt access based on authentication scopes:
 
 ```python
-from starlette.applications import Starlette
+from http_mcp.types import Arguments, NoArguments, Prompt
+from http_mcp.mcp_types.content import TextContent
+from http_mcp.mcp_types.prompts import PromptMessage
 
-from app.prompts import PROMPTS
-from http_mcp.server import MCPServer
+def private_prompt(args: Arguments[NoArguments]) -> tuple[PromptMessage, ...]:
+    """Private prompt that is only accessible to authenticated users."""
+    return (
+        PromptMessage(
+            role="user",
+            content=TextContent(text="This is a private prompt."),
+        ),
+    )
 
-app = Starlette()
-mcp_server = MCPServer(tools=(), prompts=PROMPTS, name="test", version="1.0.0")
+def admin_prompt(args: Arguments[NoArguments]) -> tuple[PromptMessage, ...]:
+    """Admin prompt accessible to users with admin or superuser scope."""
+    return (
+        PromptMessage(
+            role="user",
+            content=TextContent(text="This is an admin prompt."),
+        ),
+    )
 
-app.mount(
-    "/mcp",
-    mcp_server.app,
+PROMPTS = (
+    Prompt(
+        func=private_prompt,
+        arguments_type=NoArguments,
+        scopes=("private",),  # Only accessible with 'private' scope
+    ),
+    Prompt(
+        func=admin_prompt,
+        arguments_type=NoArguments,
+        scopes=("admin", "superuser"),  # Accessible with either scope
+    ),
 )
 ```
+
+Note: You need to set up authentication middleware in your Starlette app for
+scopes to work properly.
+
+## STDIO Transport
+
+In addition to HTTP transport, the server supports STDIO transport for
+communication. This is useful for command-line applications and integrations
+that communicate through standard input/output.
+
+### Using STDIO Transport
+
+```python
+import asyncio
+from http_mcp.server import MCPServer
+from app.tools import TOOLS
+from app.prompts import PROMPTS
+
+mcp_server = MCPServer(
+    tools=TOOLS,
+    prompts=PROMPTS,
+    name="test",
+    version="1.0.0"
+)
+
+# Run the server with STDIO transport
+async def main() -> None:
+    request_headers = {
+        "Authorization": "Bearer your-token-here",
+        "X-Custom-Header": "value",
+    }
+    await mcp_server.serve_stdio(request_headers)
+
+asyncio.run(main())
+```
+
+The `request_headers` parameter allows you to pass headers that will be included
+in the request context, enabling authentication and other header-based features
+even when using STDIO transport.
+
+## Authentication and Authorization
+
+The library integrates with Starlette's authentication system to provide
+scope-based authorization for tools and prompts.
+
+### Setting Up Authentication Middleware
+
+```python
+import contextlib
+from collections.abc import AsyncIterator
+from typing import TypedDict
+from starlette.applications import Starlette
+from starlette.authentication import (
+    AuthCredentials,
+    AuthenticationBackend,
+    BaseUser,
+    SimpleUser,
+)
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import HTTPConnection
+
+from http_mcp.server import MCPServer
+from app.context import Context
+from app.tools import TOOLS
+from app.prompts import PROMPTS
+
+
+class BasicAuthBackend(AuthenticationBackend):
+    def __init__(self, granted_scopes: tuple[str, ...] = ("authenticated",)) -> None:
+        self.granted_scopes = granted_scopes
+        super().__init__()
+
+    async def authenticate(
+        self, conn: HTTPConnection
+    ) -> tuple[AuthCredentials, BaseUser] | None:
+        # Implement your authentication logic here
+        # For example, check Bearer token, API key, etc.
+        auth_header = conn.headers.get("Authorization")
+        if not auth_header:
+            return None
+
+        # Validate token and return credentials with scopes
+        return AuthCredentials(self.granted_scopes), SimpleUser("username")
+
+
+class State(TypedDict):
+    context: Context
+
+
+@contextlib.asynccontextmanager
+async def lifespan(_app: Starlette) -> AsyncIterator[State]:
+    yield {"context": Context()}
+
+
+mcp_server = MCPServer(
+    tools=TOOLS,
+    prompts=PROMPTS,
+    name="test",
+    version="1.0.0"
+)
+
+app = Starlette(
+    lifespan=lifespan,
+    middleware=[
+        Middleware(
+            AuthenticationMiddleware,
+            backend=BasicAuthBackend(granted_scopes=("private", "admin")),
+        ),
+    ],
+)
+app.mount("/mcp", mcp_server.app)
+```
+
+### How Scopes Work
+
+1. **Authentication Middleware**: The middleware authenticates each request and
+   assigns scopes to the user through `AuthCredentials`.
+
+1. **Tool/Prompt Scopes**: When defining tools or prompts, you can specify
+   required scopes using the `scopes` parameter.
+
+1. **Access Control**: The server automatically filters tools and prompts based
+   on the user's granted scopes. Tools and prompts without the required scopes
+   are not visible in listings and cannot be invoked.
+
+1. **Multiple Scopes**: If you specify multiple scopes (e.g.,
+   `scopes=("admin", "superuser")`), the user needs at least one of those scopes
+   to access the tool or prompt.
+
+## API Reference
+
+### Tool Class
+
+The `Tool` class is used to define tools that can be invoked by clients.
+
+**Parameters:**
+
+- `func`: The function to be invoked. Can be sync or async. The function can
+  either:
+  - Accept an `Arguments[TInputs]` parameter
+  - Accept no parameters
+- `inputs`: The Pydantic model class for input validation. Use `type(None)` or
+  `NoArguments` for tools without inputs
+- `output`: The Pydantic model class for output validation
+- `return_error_message` (bool): If `True`, tool errors return `ErrorMessage`
+  instead of raising exceptions (default: `False`)
+- `scopes` (tuple[str, ...]): Required authentication scopes for accessing this
+  tool (default: empty tuple)
+
+**Properties:**
+
+- `name`: The function name (derived from `func.__name__`)
+- `title`: A human-readable title (derived from the function name)
+- `description`: The function's docstring
+- `input_schema`: JSON schema for the input parameters
+- `output_schema`: JSON schema for the output
+
+### Prompt Class
+
+The `Prompt` class is used to define prompts that can be invoked by clients.
+
+**Parameters:**
+
+- `func`: The function to be invoked. Can be sync or async. The function can
+  either:
+  - Accept an `Arguments[TArguments]` parameter
+  - Accept no parameters
+  - Must return `tuple[PromptMessage, ...]`
+- `arguments_type`: The Pydantic model class for argument validation. Use
+  `type(None)` or `NoArguments` for prompts without arguments
+- `scopes` (tuple[str, ...]): Required authentication scopes for accessing this
+  prompt (default: empty tuple)
+
+**Properties:**
+
+- `name`: The function name (derived from `func.__name__`)
+- `title`: A human-readable title (derived from the function name)
+- `description`: The function's docstring
+- `arguments`: Tuple of `PromptArgument` objects defining the prompt's arguments
+
+### Arguments Class
+
+The `Arguments` class is passed to tool and prompt functions to provide access
+to inputs, request, and state.
+
+**Parameters:**
+
+- `request`: The Starlette `Request` object
+- `inputs`: The validated input/argument data (type depends on the Tool/Prompt
+  definition)
+
+**Methods:**
+
+- `get_state_key(key: str, _object_type: type[TKey]) -> TKey`: Access a value
+  from the lifespan state. Raises `ServerError` if the key doesn't exist.
+
+### NoArguments Class
+
+An empty Pydantic model that can be used as a clearer alternative to
+`type(None)` when defining tools or prompts without arguments.
+
+```python
+from http_mcp.types import NoArguments
+
+# Use this instead of type(None)
+Tool(func=my_func, inputs=NoArguments, output=MyOutput)
+```
+
+## Installation
+
+Install the package using pip or uv:
+
+```bash
+pip install http-mcp
+```
+
+or
+
+```bash
+uv add http-mcp
+```
+
+## License
+
+This project is licensed under the MIT License. See the LICENSE file for
+details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "0.6.2"
+version = "0.7.0"
 
 dependencies = ["pydantic==2.12.3", "uvicorn==0.38.0", "starlette==0.49.1"]
 

--- a/src/http_mcp/_transport_base.py
+++ b/src/http_mcp/_transport_base.py
@@ -87,7 +87,15 @@ class BaseTransport:
                 ),
             )
         else:
-            LOGGER.error("Unsupported protocol version: %s", protocol_version)
+            LOGGER.error(
+                "Unsupported protocol version: %s",
+                protocol_version,
+                extra={
+                    "extra": {
+                        "initialization_request": message.model_dump(mode="json", by_alias=True),
+                    },
+                },
+            )
             status_code = HTTPStatus.BAD_REQUEST
             response = JSONRPCError(
                 jsonrpc="2.0",
@@ -109,7 +117,7 @@ class BaseTransport:
         request: Request,
     ) -> PromptsListResponse | JSONRPCError | PromptsGetResponse:
         if message.method == "prompts/list":
-            result = self._server.list_prompts()
+            result = self._server.list_prompts(request)
             return PromptsListResponse(
                 jsonrpc="2.0",
                 id=message.id,
@@ -154,7 +162,7 @@ class BaseTransport:
         request: Request,
     ) -> JSONRPCMessage | JSONRPCError:
         if message.method == "tools/list":
-            tools = self._server.list_tools()
+            tools = self._server.list_tools(request)
             return ToolsListResponse(
                 jsonrpc="2.0",
                 id=message.id,

--- a/src/http_mcp/server_interface.py
+++ b/src/http_mcp/server_interface.py
@@ -38,11 +38,11 @@ class ServerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def list_tools(self) -> tuple[dict, ...]:
+    def list_tools(self, request: Request) -> tuple[dict, ...]:
         raise NotImplementedError
 
     @abstractmethod
-    def list_prompts(self) -> PromptListResult:
+    def list_prompts(self, request: Request) -> PromptListResult:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/http_mcp/types/__init__.py
+++ b/src/http_mcp/types/__init__.py
@@ -1,5 +1,5 @@
-from .models import Arguments
+from .models import Arguments, NoArguments
 from .prompts import Prompt
 from .tools import Tool
 
-__all__ = ["Arguments", "Prompt", "Tool"]
+__all__ = ["Arguments", "NoArguments", "Prompt", "Tool"]

--- a/src/http_mcp/types/models.py
+++ b/src/http_mcp/types/models.py
@@ -7,6 +7,10 @@ from starlette.requests import Request
 from http_mcp.exceptions import ServerError
 
 
+class NoArguments(BaseModel):
+    pass
+
+
 @dataclass
 class Arguments[TInputs: BaseModel | None]:
     request: Request

--- a/src/http_mcp/types/prompts.py
+++ b/src/http_mcp/types/prompts.py
@@ -25,6 +25,7 @@ class Prompt[TArguments: BaseModel | None]:
         ]
     )
     arguments_type: type[TArguments]
+    scopes: tuple[str, ...] = ()
 
     @property
     def arguments(self) -> tuple[PromptArgument, ...]:

--- a/src/http_mcp/types/tools.py
+++ b/src/http_mcp/types/tools.py
@@ -32,6 +32,9 @@ class Tool[TInputs: BaseModel | None, TOutput: BaseModel]:
         will be returned instead of returning a JSONRPCError.
         If False (default), returns the raw output model directly or raises a ToolInvocationError.
 
+        scopes: Works the same as starlette's scope. Is used to exposed tools given authorization
+        scopes.
+
     """
 
     func: (
@@ -46,8 +49,8 @@ class Tool[TInputs: BaseModel | None, TOutput: BaseModel]:
     )
     inputs: type[TInputs]
     output: type[TOutput]
-
     return_error_message: bool = False
+    scopes: tuple[str, ...] = ()
 
     @property
     def annotations(self) -> Mapping[str, str | bool]:

--- a/tests/app/main.py
+++ b/tests/app/main.py
@@ -6,6 +6,15 @@ from typing import TypedDict
 
 import uvicorn
 from starlette.applications import Starlette
+from starlette.authentication import (
+    AuthCredentials,
+    AuthenticationBackend,
+    BaseUser,
+    SimpleUser,
+)
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import HTTPConnection
 
 from http_mcp.server import MCPServer
 from tests.app.context import Context
@@ -13,6 +22,16 @@ from tests.app.prompts import PROMPTS
 from tests.app.tools import TOOLS
 
 mcp_server = MCPServer(tools=TOOLS, prompts=PROMPTS, name="test", version="1.0.0")
+
+
+class BasicAuthBackend(AuthenticationBackend):
+    def __init__(self, granted_scopes: tuple[str, ...] = ("authenticated",)) -> None:
+        self.granted_scopes = granted_scopes
+
+        super().__init__()
+
+    async def authenticate(self, _conn: HTTPConnection) -> tuple[AuthCredentials, BaseUser] | None:
+        return AuthCredentials(self.granted_scopes), SimpleUser("test_user")
 
 
 class State(TypedDict):
@@ -24,15 +43,34 @@ async def lifespan(_app: Starlette) -> AsyncIterator[State]:
     yield {"context": Context(called_tools=[])}
 
 
-def mount_mcp_server(mcp_server: MCPServer) -> Starlette:
-    app = Starlette(lifespan=lifespan)
-    app.mount("/mcp", mcp_server.app)
+def mount_mcp_server(
+    server: MCPServer,
+    authentication_backend: AuthenticationBackend | None = None,
+) -> Starlette:
+    app = Starlette(
+        lifespan=lifespan,
+        middleware=[
+            Middleware(
+                AuthenticationMiddleware,
+                backend=authentication_backend,
+            ),
+        ]
+        if authentication_backend
+        else None,
+    )
+    app.mount("/mcp", server.app)
     return app
 
 
 def run_http() -> None:
     app = Starlette(
         lifespan=lifespan,
+        middleware=[
+            Middleware(
+                AuthenticationMiddleware,
+                backend=BasicAuthBackend(granted_scopes=("private",)),
+            ),
+        ],
     )
     app.mount(
         "/mcp",
@@ -46,3 +84,7 @@ def run_stdio() -> None:
         "Authorization": os.getenv("AUTHORIZATION_TOKEN", ""),
     }
     asyncio.run(mcp_server.serve_stdio(request_headers), debug=True)
+
+
+if __name__ == "__main__":
+    run_http()

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "http-mcp"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Major improvements:

- Add NoArguments class
- Add authorization scopes support for tools and prompts
- Integrate with Starlette's authentication system for scope-based access control
- Export NoArguments from http_mcp.types module

Documentation:
- Add comprehensive README with table of contents
- Document tools without arguments and error handling
- Document prompts without arguments and authorization scopes
- Add STDIO transport usage examples
- Add authentication and authorization setup guide
- Add complete API reference for Tool, Prompt, Arguments, and NoArguments classes
- Reorganize sections for better navigation

Tests:
- Update test tools and prompts to use NoArguments
- Add tests for scope-based authorization
- Update test app with authentication middleware examples

Bump version to 0.7.0