### PR TITLE
package(feat): #55 replace CORSConfig with middlewares and use Protec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,9 +542,7 @@ support lifespan state access, similar to tools.
 ```python
 from pydantic import BaseModel, Field
 
-from http_mcp._mcp_types.content import TextContent
-from http_mcp._mcp_types.prompts import PromptMessage
-from http_mcp.types import Arguments, Prompt
+from http_mcp.types import Arguments, Prompt, PromptMessage, TextContent
 
 
 class GetAdvice(BaseModel):
@@ -955,6 +953,7 @@ from auth_mcp.resource_server import (
     TokenValidator,
     create_protected_mcp_app,
 )
+from auth_mcp.types import ProtectedResourceMetadata
 
 
 class MyTokenValidator(TokenValidator):
@@ -970,8 +969,10 @@ mcp_server = MCPServer(name="my-server", version="1.0.0", tools=MY_TOOLS)
 config = ProtectedMCPAppConfig(
     mcp_server=mcp_server,
     token_validator=MyTokenValidator(),
-    resource_uri="https://mcp.example.com",
-    authorization_servers=("https://auth.example.com",),
+    resource_endpoint=ProtectedResourceMetadata(
+        resource="https://mcp.example.com",
+        authorization_servers=("https://auth.example.com",),
+    ),
 )
 
 app = create_protected_mcp_app(config)
@@ -983,7 +984,7 @@ This gives you:
 - `/.well-known/oauth-protected-resource` discovery endpoint (RFC 9728)
 - `WWW-Authenticate` headers on 401/403 with `resource_metadata` parameter
 - Security headers (HSTS, nosniff, no-store)
-- Optional CORS configuration via `CORSConfig`
+- Optional custom middleware via the `middlewares` parameter
 
 For full documentation, best practices, and security surface details, see
 [auth_mcp README](src/auth_mcp/README.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
-version = "0.11.3"
+version = "0.12.0rc1"
 
 dependencies = ["pydantic (>=2.12.5,<3.0.0)", "uvicorn (>=0.41.0,<0.42.0)", "starlette (>=0.52.1,<1.2.0)"]
 

--- a/src/auth_mcp/README.md
+++ b/src/auth_mcp/README.md
@@ -46,6 +46,7 @@ from auth_mcp.resource_server import (
     TokenValidator,
     create_protected_mcp_app,
 )
+from auth_mcp.types import ProtectedResourceMetadata
 
 
 class MyTokenValidator(TokenValidator):
@@ -62,9 +63,11 @@ mcp_server = MCPServer(name="my-server", version="1.0.0", tools=MY_TOOLS)
 config = ProtectedMCPAppConfig(
     mcp_server=mcp_server,
     token_validator=MyTokenValidator(),
-    resource_uri="https://mcp.example.com",
-    authorization_servers=("https://auth.example.com",),
-    scopes_supported=("read", "write"),
+    resource_endpoint=ProtectedResourceMetadata(
+        resource="https://mcp.example.com",
+        authorization_servers=("https://auth.example.com",),
+        scopes_supported=("read", "write"),
+    ),
 )
 
 app = create_protected_mcp_app(config)
@@ -92,7 +95,7 @@ Incoming HTTP request
         │
         ▼
 ┌─────────────────────────┐
-│     CORSMiddleware      │  (optional — only when config.cors is set)
+│  Custom Middlewares      │  (optional — from config.middlewares)
 └───────────┬─────────────┘
             │
             ▼
@@ -259,23 +262,22 @@ and `\` escaped per RFC 7230).
 
 ```python
 from auth_mcp.resource_server import (
-    CORSConfig,
     ProtectedMCPAppConfig,
     create_protected_mcp_app,
 )
+from auth_mcp.types import ProtectedResourceMetadata
 
 config = ProtectedMCPAppConfig(
     mcp_server=mcp_server,
     token_validator=my_validator,
-    resource_uri="https://mcp.example.com",
-    authorization_servers=("https://auth.example.com",),
-    scopes_supported=("read", "write"),
+    resource_endpoint=ProtectedResourceMetadata(
+        resource="https://mcp.example.com",
+        authorization_servers=("https://auth.example.com",),
+        scopes_supported=("read", "write"),
+    ),
     mcp_path="/mcp",                 # MCP endpoint mount path
     realm="my-mcp-server",           # WWW-Authenticate realm
     require_authentication=True,     # enforce auth (default)
-    cors=CORSConfig(                 # optional CORS
-        allow_origins=("https://client.example.com",),
-    ),
 )
 
 app = create_protected_mcp_app(config)
@@ -347,15 +349,15 @@ or expired tokens are silently treated as unauthenticated rather than rejected.
 `Strict-Transport-Security` headers, but TLS termination must be configured at
 the reverse proxy or load balancer.
 
-**Set specific CORS origins.** Never use `allow_origins=("*",)` with
+**Set specific CORS origins.** Never use `allow_origins=["*"]` with
 `allow_credentials=True`. Always list the exact origins that need access.
 
 ```python
 # Good: specific origins
-cors=CORSConfig(allow_origins=("https://app.example.com",))
+Middleware(CORSMiddleware, allow_origins=["https://app.example.com"])
 
 # Bad: wildcard with credentials
-cors=CORSConfig(allow_origins=("*",), allow_credentials=True)
+Middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True)
 ```
 
 **Use the metadata endpoint for discovery.** Clients should fetch
@@ -412,8 +414,10 @@ config = ProtectedMCPAppConfig(
         issuer="https://auth.example.com",
         audience="https://mcp.example.com",
     ),
-    resource_uri="https://mcp.example.com",
-    authorization_servers=("https://auth.example.com",),
+    resource_endpoint=ProtectedResourceMetadata(
+        resource="https://mcp.example.com",
+        authorization_servers=("https://auth.example.com",),
+    ),
 )
 
 app = create_protected_mcp_app(config)
@@ -447,9 +451,11 @@ TOOLS = (
 config = ProtectedMCPAppConfig(
     mcp_server=MCPServer(name="api", version="1.0.0", tools=TOOLS),
     token_validator=my_validator,
-    resource_uri="https://mcp.example.com",
-    authorization_servers=("https://auth.example.com",),
-    require_authentication=False,  # allow public access to unsoped tools
+    resource_endpoint=ProtectedResourceMetadata(
+        resource="https://mcp.example.com",
+        authorization_servers=("https://auth.example.com",),
+    ),
+    require_authentication=False,  # allow public access to unscoped tools
 )
 
 app = create_protected_mcp_app(config)
@@ -461,24 +467,33 @@ and `list_models`. Authenticated users with the right scopes also see
 
 ### Browser-Based MCP Client with CORS
 
-Enable cross-origin access for a browser-based client:
+Enable cross-origin access for a browser-based client using the `middlewares`
+parameter with Starlette's `CORSMiddleware`:
 
 ```python
-from auth_mcp.resource_server import CORSConfig, ProtectedMCPAppConfig
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from auth_mcp.resource_server import ProtectedMCPAppConfig
+from auth_mcp.types import ProtectedResourceMetadata
 
 config = ProtectedMCPAppConfig(
     mcp_server=mcp_server,
     token_validator=my_validator,
-    resource_uri="https://mcp.example.com",
-    authorization_servers=("https://auth.example.com",),
-    cors=CORSConfig(
-        allow_origins=(
-            "https://app.example.com",
-            "https://staging.example.com",
+    resource_endpoint=ProtectedResourceMetadata(
+        resource="https://mcp.example.com",
+        authorization_servers=("https://auth.example.com",),
+    ),
+    middlewares=(
+        Middleware(
+            CORSMiddleware,
+            allow_origins=[
+                "https://app.example.com",
+                "https://staging.example.com",
+            ],
+            allow_methods=["GET", "POST"],
+            allow_headers=["Authorization", "Content-Type"],
+            allow_credentials=True,
         ),
-        allow_methods=("GET", "POST"),
-        allow_headers=("Authorization", "Content-Type"),
-        allow_credentials=True,
     ),
 )
 

--- a/src/auth_mcp/resource_server/__init__.py
+++ b/src/auth_mcp/resource_server/__init__.py
@@ -1,6 +1,5 @@
 from auth_mcp.resource_server.authentication_backend import OAuthAuthenticationBackend
 from auth_mcp.resource_server.integration import (
-    CORSConfig,
     ProtectedMCPAppConfig,
     create_protected_mcp_app,
 )
@@ -14,7 +13,6 @@ from auth_mcp.resource_server.token_validator import TokenInfo, TokenValidator
 
 __all__ = (
     "AuthErrorMiddleware",
-    "CORSConfig",
     "OAuthAuthenticationBackend",
     "ProtectedMCPAppConfig",
     "ProtectedResourceMetadataEndpoint",

--- a/src/auth_mcp/resource_server/integration.py
+++ b/src/auth_mcp/resource_server/integration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
@@ -12,27 +11,12 @@ from starlette.routing import Mount, Route
 from auth_mcp.resource_server.authentication_backend import OAuthAuthenticationBackend
 from auth_mcp.resource_server.metadata_endpoint import ProtectedResourceMetadataEndpoint
 from auth_mcp.resource_server.middleware import AuthErrorMiddleware, on_auth_error
-from auth_mcp.types.metadata import ProtectedResourceMetadata
 
 if TYPE_CHECKING:
     from auth_mcp.authorization_server.client_store import ClientStore
     from auth_mcp.resource_server.token_validator import TokenValidator
-    from auth_mcp.types.metadata import AuthorizationServerMetadata
+    from auth_mcp.types.metadata import AuthorizationServerMetadata, ProtectedResourceMetadata
     from http_mcp.server import MCPServer
-
-
-@dataclass(frozen=True)
-class CORSConfig:
-    """CORS configuration for the protected MCP application.
-
-    Only set ``allow_origins`` to specific trusted origins. Using ``["*"]``
-    with ``allow_credentials=True`` is insecure and will be rejected by browsers.
-    """
-
-    allow_origins: tuple[str, ...] = ()
-    allow_methods: tuple[str, ...] = ("GET", "POST")
-    allow_headers: tuple[str, ...] = ("Authorization", "Content-Type")
-    allow_credentials: bool = True
 
 
 @dataclass(frozen=True)
@@ -46,17 +30,24 @@ class ProtectedMCPAppConfig:
 
     mcp_server: MCPServer
     token_validator: TokenValidator
-    resource_uri: str
-    authorization_servers: tuple[str, ...]
-    scopes_supported: tuple[str, ...] | None = None
+    resource_endpoint: ProtectedResourceMetadata
     mcp_path: str = "/mcp"
     realm: str | None = None
     require_authentication: bool = True
-    cors: CORSConfig | None = None
     authorization_server_metadata: AuthorizationServerMetadata | None = None
     client_store: ClientStore | None = None
-    extra_middleware: tuple[Middleware, ...] = field(default_factory=tuple)
+    middlewares: tuple[Middleware, ...] = field(default_factory=tuple)
 
+
+def _get_registration_endpoint_path(
+    config: ProtectedMCPAppConfig,
+) -> str:
+    if (
+        config.authorization_server_metadata
+        and config.authorization_server_metadata.registration_endpoint is not None
+    ):
+        return config.authorization_server_metadata.registration_endpoint.path or "/register"
+    return "/register"
 
 def create_protected_mcp_app(
     config: ProtectedMCPAppConfig,
@@ -69,37 +60,17 @@ def create_protected_mcp_app(
     - OAuthAuthenticationBackend for Bearer token validation
     - AuthErrorMiddleware for WWW-Authenticate headers on 401/403
     - Protected Resource Metadata at /.well-known/oauth-protected-resource
-    - Optional CORS middleware via ``config.cors``
+    - Optional custom middleware via ``config.middlewares``
     """
-    metadata = ProtectedResourceMetadata(
-        resource=AnyHttpUrl(config.resource_uri),
-        authorization_servers=tuple(AnyHttpUrl(url) for url in config.authorization_servers),
-        scopes_supported=config.scopes_supported,
-    )
-    metadata_endpoint = ProtectedResourceMetadataEndpoint(metadata)
+    metadata_endpoint = ProtectedResourceMetadataEndpoint(config.resource_endpoint)
     resource_metadata_url = (
         f"/.well-known/oauth-protected-resource{config.mcp_path}"
     )
 
-
-    middlewares: list[Middleware] = []
-
-    if config.cors is not None:
-        from starlette.middleware.cors import CORSMiddleware  # noqa: PLC0415
-
-        middlewares.append(
-            Middleware(
-                CORSMiddleware,
-                allow_origins=list(config.cors.allow_origins),
-                allow_methods=list(config.cors.allow_methods),
-                allow_headers=list(config.cors.allow_headers),
-                allow_credentials=config.cors.allow_credentials,
-            ),
-        )
-
     routes: list[Route | Mount] = [
+        # ends with / because server app is mounted at /
         Route(
-            f"/.well-known/oauth-protected-resource{config.mcp_path}",
+            f"/.well-known/oauth-protected-resource{config.mcp_path}/",
             metadata_endpoint,
         ),
     ]
@@ -112,11 +83,9 @@ def create_protected_mcp_app(
         as_metadata_endpoint = AuthorizationServerMetadataEndpoint(
             config.authorization_server_metadata,
         )
-        auth_server_metadata_path = (
-
-                "/.well-known/oauth-authorization-server"
-                f"{config.authorization_server_metadata.issuer.path or ''}"
-        )
+        _path = config.authorization_server_metadata.issuer.path or ""
+        auth_server_path = _path if _path != "/" else ""
+        auth_server_metadata_path = f"/.well-known/oauth-authorization-server{auth_server_path}"
         routes.append(
             Route(
                 auth_server_metadata_path,
@@ -130,7 +99,8 @@ def create_protected_mcp_app(
         )
 
         registration_endpoint = DynamicClientRegistrationEndpoint(config.client_store)
-        routes.append(Route("/register", registration_endpoint))
+        registration_path = _get_registration_endpoint_path(config)
+        routes.append(Route(registration_path, registration_endpoint))
 
 
     routes.append(
@@ -147,19 +117,18 @@ def create_protected_mcp_app(
                     AuthenticationMiddleware,
                         backend=OAuthAuthenticationBackend(
                         token_validator=config.token_validator,
-                        resource_uri=config.resource_uri,
+                        resource_uri=str(config.resource_endpoint.resource),
                         require_authentication=config.require_authentication,
                     ),
                     on_error=on_auth_error,
                 ),
-                *config.extra_middleware,
-                *middlewares,
+                *config.middlewares,
             ],
         ),
     )
 
     return Starlette(
         routes=routes,
-        middleware=middlewares + list(config.extra_middleware),
+        middleware=list(config.middlewares),
         **starlette_kwargs,  # type: ignore[arg-type]
     )

--- a/tests/auth_mcp/resource_server/test_integration.py
+++ b/tests/auth_mcp/resource_server/test_integration.py
@@ -1,15 +1,16 @@
 from http import HTTPStatus
 
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
 from starlette.testclient import TestClient
 
 from auth_mcp.authorization_server.client_store import ClientStore
 from auth_mcp.resource_server.integration import (
-    CORSConfig,
     ProtectedMCPAppConfig,
     create_protected_mcp_app,
 )
 from auth_mcp.resource_server.token_validator import TokenInfo, TokenValidator
-from auth_mcp.types.metadata import AuthorizationServerMetadata
+from auth_mcp.types.metadata import AuthorizationServerMetadata, ProtectedResourceMetadata
 from auth_mcp.types.registration import ClientRegistrationRequest, ClientRegistrationResponse
 from http_mcp.server import MCPServer
 from http_mcp.types import Tool
@@ -97,9 +98,11 @@ def _create_app(*, require_authentication: bool = True) -> TestClient:
     config = ProtectedMCPAppConfig(
         mcp_server=server,
         token_validator=MockTokenValidator(),
-        resource_uri="https://mcp.example.com",
-        authorization_servers=("https://auth.example.com",),
-        scopes_supported=("read", "write", "private"),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://mcp.example.com",
+            authorization_servers=("https://auth.example.com",),
+            scopes_supported=("read", "write", "private"),
+        ),
         require_authentication=require_authentication,
     )
     app = create_protected_mcp_app(config)
@@ -215,12 +218,14 @@ def test_cors_config_adds_cors_headers() -> None:
     config = ProtectedMCPAppConfig(
         mcp_server=server,
         token_validator=MockTokenValidator(),
-        resource_uri="https://mcp.example.com",
-        authorization_servers=("https://auth.example.com",),
-        require_authentication=False,
-        cors=CORSConfig(
-            allow_origins=("https://client.example.com",),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://mcp.example.com",
+            authorization_servers=("https://auth.example.com",),
         ),
+        require_authentication=False,
+        middlewares=[
+            Middleware(CORSMiddleware, allow_origins=("https://client.example.com",)),
+        ],
     )
     app = create_protected_mcp_app(config)
     client = TestClient(app)
@@ -241,8 +246,10 @@ def test_authorization_server_metadata_endpoint() -> None:
     config = ProtectedMCPAppConfig(
         mcp_server=server,
         token_validator=MockTokenValidator(),
-        resource_uri="https://mcp.example.com",
-        authorization_servers=("https://auth.example.com",),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://mcp.example.com",
+            authorization_servers=("https://auth.example.com",),
+        ),
         require_authentication=False,
         authorization_server_metadata=_AS_METADATA,
     )
@@ -261,8 +268,10 @@ def test_client_store_serves_register_endpoint() -> None:
     config = ProtectedMCPAppConfig(
         mcp_server=server,
         token_validator=MockTokenValidator(),
-        resource_uri="https://mcp.example.com",
-        authorization_servers=("https://auth.example.com",),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://mcp.example.com",
+            authorization_servers=("https://auth.example.com",),
+        ),
         require_authentication=False,
         client_store=MockClientStore(),
     )
@@ -297,8 +306,10 @@ def test_full_discovery_flow() -> None:
     config = ProtectedMCPAppConfig(
         mcp_server=server,
         token_validator=MockTokenValidator(),
-        resource_uri="https://mcp.example.com",
-        authorization_servers=("https://auth.example.com",),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://mcp.example.com",
+            authorization_servers=("https://auth.example.com",),
+        ),
         require_authentication=False,
         authorization_server_metadata=_AS_METADATA,
         client_store=MockClientStore(),

--- a/tests/integration/test_auth_app.py
+++ b/tests/integration/test_auth_app.py
@@ -6,19 +6,21 @@ tests/app/ to verify the full OAuth 2.1 authorization flow end-to-end.
 
 from http import HTTPStatus
 
+from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from auth_mcp.resource_server.integration import ProtectedMCPAppConfig, create_protected_mcp_app
 from auth_mcp.resource_server.token_validator import TokenInfo, TokenValidator
+from auth_mcp.types.metadata import ProtectedResourceMetadata
 from http_mcp.server import MCPServer
 from tests.fixtures.main import lifespan
 from tests.fixtures.prompts import PROMPTS
 from tests.fixtures.tools import TOOLS
 
 _VALID_TOKEN = "test_oauth_token"  # noqa: S105
-_RESOURCE_URI = "https://mcp.example.com"
-_AUTH_SERVER = "https://auth.example.com"
+_RESOURCE_URI = AnyHttpUrl("https://mcp.example.com")
+_AUTH_SERVER = AnyHttpUrl("https://auth.example.com")
 
 
 class _MockTokenValidator(TokenValidator):
@@ -52,9 +54,11 @@ def _create_starlette_app(
     config = ProtectedMCPAppConfig(
         mcp_server=server,
         token_validator=_MockTokenValidator(scopes=scopes),
-        resource_uri=_RESOURCE_URI,
-        authorization_servers=(_AUTH_SERVER,),
-        scopes_supported=("private", "superuser"),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource=_RESOURCE_URI,
+            authorization_servers=(_AUTH_SERVER,),
+            scopes_supported=("private", "superuser"),
+        ),
         require_authentication=require_authentication,
     )
     return create_protected_mcp_app(config, lifespan=lifespan)
@@ -90,12 +94,12 @@ def _post_mcp(
 
 
 def test_metadata_endpoint_returns_resource_info() -> None:
-    client = _create_app(require_authentication=False)
+    client = _create_app()
     response = client.get("/.well-known/oauth-protected-resource/mcp/")
     assert response.status_code == HTTPStatus.OK
     data = response.json()
-    assert data["resource"] == f"{_RESOURCE_URI}/"
-    assert f"{_AUTH_SERVER}/" in data["authorization_servers"]
+    assert data["resource"] == str(_RESOURCE_URI)
+    assert str(_AUTH_SERVER) in data["authorization_servers"]
     assert data["scopes_supported"] == ["private", "superuser"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "http-mcp"
-version = "0.11.3"
+version = "0.12.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
…tedResourceMetadata in config

Refactor ProtectedMCPAppConfig to accept resource_endpoint (ProtectedResourceMetadata) instead of separate resource_uri/authorization_servers/scopes_supported params. Remove CORSConfig in favor of a generic middlewares tuple. Update docs, tests, and bump version to 0.12.0rc1.