### PR TITLE
package(fix): #55 use absolute URL for resource_metadata in WWW-Authe…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
-version = "0.12.0rc1"
+version = "0.12.0rc2"
 
 dependencies = ["pydantic (>=2.12.5,<3.0.0)", "uvicorn (>=0.41.0,<0.42.0)", "starlette (>=0.52.1,<1.2.0)"]
 

--- a/src/auth_mcp/resource_server/integration.py
+++ b/src/auth_mcp/resource_server/integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -63,8 +64,10 @@ def create_protected_mcp_app(
     - Optional custom middleware via ``config.middlewares``
     """
     metadata_endpoint = ProtectedResourceMetadataEndpoint(config.resource_endpoint)
+    parsed = urlparse(str(config.resource_endpoint.resource))
+    resource_origin = f"{parsed.scheme}://{parsed.netloc}"
     resource_metadata_url = (
-        f"/.well-known/oauth-protected-resource{config.mcp_path}"
+        f"{resource_origin}/.well-known/oauth-protected-resource{config.mcp_path}/"
     )
 
     routes: list[Route | Mount] = [

--- a/tests/auth_mcp/resource_server/test_integration.py
+++ b/tests/auth_mcp/resource_server/test_integration.py
@@ -301,6 +301,91 @@ def test_no_client_store_returns_404() -> None:
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
+_EXPECTED_METADATA_URL = (
+    "https://mcp.example.com/.well-known/oauth-protected-resource/mcp/"
+)
+
+
+def test_www_authenticate_resource_metadata_is_absolute_url_on_401() -> None:
+    client = _create_app(require_authentication=True)
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1, "params": {}},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    www_auth = response.headers["www-authenticate"]
+    assert f'resource_metadata="{_EXPECTED_METADATA_URL}"' in www_auth
+
+
+def test_www_authenticate_resource_metadata_is_absolute_url_on_403() -> None:
+    client = _create_app(require_authentication=True)
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "_private_tool", "arguments": {}},
+        },
+        headers={"Authorization": f"Bearer {_PUBLIC_ONLY_TOKEN}"},
+    )
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    www_auth = response.headers["www-authenticate"]
+    assert f'resource_metadata="{_EXPECTED_METADATA_URL}"' in www_auth
+
+
+def test_www_authenticate_resource_metadata_uses_origin_only() -> None:
+    """Resource URL with a path: only origin is used in the metadata URL."""
+    server = MCPServer(name="test-path", version="1.0.0", tools=_TOOLS)
+    config = ProtectedMCPAppConfig(
+        mcp_server=server,
+        token_validator=MockTokenValidator(),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://api.example.com/v1",
+            authorization_servers=("https://auth.example.com",),
+        ),
+        require_authentication=True,
+    )
+    app = create_protected_mcp_app(config)
+    client = TestClient(app)
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1, "params": {}},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    www_auth = response.headers["www-authenticate"]
+    expected = (
+        "https://api.example.com"
+        "/.well-known/oauth-protected-resource/mcp/"
+    )
+    assert f'resource_metadata="{expected}"' in www_auth
+
+
+def test_www_authenticate_resource_metadata_port_included_when_present() -> None:
+    server = MCPServer(name="test-port", version="1.0.0", tools=_TOOLS)
+    config = ProtectedMCPAppConfig(
+        mcp_server=server,
+        token_validator=MockTokenValidator(),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="http://localhost:8443",
+            authorization_servers=("https://auth.example.com",),
+        ),
+        require_authentication=True,
+    )
+    app = create_protected_mcp_app(config)
+    client = TestClient(app)
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1, "params": {}},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    www_auth = response.headers["www-authenticate"]
+    expected = (
+        "http://localhost:8443"
+        "/.well-known/oauth-protected-resource/mcp/"
+    )
+    assert f'resource_metadata="{expected}"' in www_auth
+
 def test_full_discovery_flow() -> None:
     server = MCPServer(name="test-flow", version="1.0.0", tools=_TOOLS)
     config = ProtectedMCPAppConfig(

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "http-mcp"
-version = "0.12.0rc1"
+version = "0.12.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
…nticate header

The resource_metadata_url was built as a relative path, but MCP clients require an absolute URL per RFC 9728. Extract the origin from the resource endpoint URL and prepend it to the well-known path.