### PR TITLE
package(feat): allow custom redirect URI schemes via opt-in allowlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
-version = "0.12.0"
+version = "0.13.0"
 
 dependencies = ["pydantic (>=2.12.5,<3.0.0)", "uvicorn (>=0.41.0,<0.42.0)", "starlette (>=0.52.1,<1.2.0)"]
 
@@ -28,7 +28,7 @@ dev = [
     "httpx (>=0.28.1,<0.29.0)",
     "mdformat (>=1.0.0,<2.0.0)",
     "mypy (>=1.19.1,<2.0.0)",
-    "pytest (>=9.0.2,<10.0.0)",
+    "pytest (>=9.0.3,<10.0.0)",
     "ruff (>=0.15.2,<0.16.0)",
     "pytest-cov (>=7.0.0,<8.0.0)",
     "pytest-asyncio (>=1.3.0,<2.0.0)",

--- a/src/auth_mcp/authorization_server/registration_endpoint.py
+++ b/src/auth_mcp/authorization_server/registration_endpoint.py
@@ -10,7 +10,10 @@ from starlette.types import Receive, Scope, Send
 from auth_mcp.authorization_server.client_store import ClientStore
 from auth_mcp.exceptions import RegistrationError
 from auth_mcp.types.errors import OAuthErrorResponse
-from auth_mcp.types.registration import ClientRegistrationRequest
+from auth_mcp.types.registration import (
+    DISALLOWED_REDIRECT_SCHEMES,
+    ClientRegistrationRequest,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,8 +51,28 @@ class DynamicClientRegistrationEndpoint:
     body as a ``ClientRegistrationRequest`` and delegates to a ``ClientStore``.
     """
 
-    def __init__(self, client_store: ClientStore) -> None:
+    def __init__(
+        self,
+        client_store: ClientStore,
+        allowed_custom_redirect_schemes: frozenset[str] | set[str] | tuple[str, ...] = (),
+    ) -> None:
+        normalized = frozenset(s.lower() for s in allowed_custom_redirect_schemes)
+        conflicts = normalized & DISALLOWED_REDIRECT_SCHEMES
+        if conflicts:
+            msg = (
+                "allowed_custom_redirect_schemes must not include disallowed "
+                f"schemes: {sorted(conflicts)}"
+            )
+            raise ValueError(msg)
+        for reserved in ("http", "https"):
+            if reserved in normalized:
+                msg = (
+                    "allowed_custom_redirect_schemes must not include "
+                    f"{reserved!r}; it is already handled by default rules"
+                )
+                raise ValueError(msg)
         self._client_store = client_store
+        self._allowed_custom_redirect_schemes = normalized
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
@@ -100,14 +123,13 @@ class DynamicClientRegistrationEndpoint:
             headers=_SECURITY_HEADERS,
         )
 
-    @staticmethod
-    def _parse_body(body: bytes) -> ClientRegistrationRequest | Response:
+    def _parse_body(self, body: bytes) -> ClientRegistrationRequest | Response:
         try:
-            data = json.loads(body)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return _error_response("Invalid JSON")
-
-        try:
-            return ClientRegistrationRequest.model_validate(data)
+            return ClientRegistrationRequest.model_validate_json(
+                body,
+                context={
+                    "allowed_custom_redirect_schemes": self._allowed_custom_redirect_schemes,
+                },
+            )
         except ValidationError as exc:
             return _error_response(str(exc.errors()[0]["msg"]))

--- a/src/auth_mcp/resource_server/integration.py
+++ b/src/auth_mcp/resource_server/integration.py
@@ -37,6 +37,7 @@ class ProtectedMCPAppConfig:
     require_authentication: bool = True
     authorization_server_metadata: AuthorizationServerMetadata | None = None
     client_store: ClientStore | None = None
+    allowed_custom_redirect_schemes: frozenset[str] = field(default_factory=frozenset)
     middlewares: tuple[Middleware, ...] = field(default_factory=tuple)
 
 
@@ -101,7 +102,10 @@ def create_protected_mcp_app(
             DynamicClientRegistrationEndpoint,
         )
 
-        registration_endpoint = DynamicClientRegistrationEndpoint(config.client_store)
+        registration_endpoint = DynamicClientRegistrationEndpoint(
+            config.client_store,
+            allowed_custom_redirect_schemes=config.allowed_custom_redirect_schemes,
+        )
         registration_path = _get_registration_endpoint_path(config)
         routes.append(Route(registration_path, registration_endpoint))
 

--- a/src/auth_mcp/types/registration.py
+++ b/src/auth_mcp/types/registration.py
@@ -1,10 +1,44 @@
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
+
+# Schemes that must never be accepted as redirect URIs. ``javascript`` and
+# ``data`` are XSS vectors; the others are non-web or non-navigable schemes
+# that make no sense as OAuth redirect targets. This set is non-negotiable:
+# callers cannot opt these back in via ``allowed_custom_redirect_schemes``.
+DISALLOWED_REDIRECT_SCHEMES: frozenset[str] = frozenset(
+    {
+        "javascript",
+        "data",
+        "file",
+        "vbscript",
+        "about",
+        "blob",
+        "mailto",
+        "tel",
+        "ws",
+        "wss",
+        "ftp",
+        "ftps",
+        # Android intent scheme — can launch arbitrary activities with
+        # attacker-controlled extras (e.g.
+        # ``intent://evil#Intent;scheme=http;S.browser_fallback_url=...;end``).
+        "intent",
+        # Browser source-viewer pseudo-scheme.
+        "view-source",
+    },
+)
 
 
 class ClientRegistrationRequest(BaseModel):
-    """RFC 7591 dynamic client registration request."""
+    """RFC 7591 dynamic client registration request.
+
+    Redirect URI validation accepts ``https`` unconditionally, ``http`` only
+    for ``localhost`` / ``127.0.0.1`` / ``::1``, and any custom scheme listed
+    in the ``allowed_custom_redirect_schemes`` validation context entry
+    (RFC 8252 — OAuth 2.0 for Native Apps). Schemes in
+    :data:`DISALLOWED_REDIRECT_SCHEMES` are always rejected.
+    """
 
     model_config = ConfigDict(frozen=True)
 
@@ -16,20 +50,58 @@ class ClientRegistrationRequest(BaseModel):
 
     @field_validator("redirect_uris")
     @classmethod
-    def _validate_redirect_uris(cls, v: tuple[str, ...]) -> tuple[str, ...]:
+    def _validate_redirect_uris(
+        cls,
+        v: tuple[str, ...],
+        info: ValidationInfo,
+    ) -> tuple[str, ...]:
+        allowed_custom: frozenset[str] = frozenset()
+        if info.context is not None:
+            raw = info.context.get("allowed_custom_redirect_schemes")
+            if raw is not None:
+                allowed_custom = frozenset(s.lower() for s in raw)
         for uri in v:
-            parsed = urlparse(uri)
-            if not parsed.scheme or not parsed.netloc:
-                msg = f"Redirect URI must be an absolute URI: {uri}"
-                raise ValueError(msg)
-            is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
-            if parsed.scheme not in ("https", "http"):
-                msg = f"Redirect URI must use HTTPS (or HTTP for localhost): {uri}"
-                raise ValueError(msg)
-            if parsed.scheme == "http" and not is_localhost:
-                msg = f"HTTP redirect URIs are only allowed for localhost: {uri}"
-                raise ValueError(msg)
+            _validate_single_redirect_uri(uri, allowed_custom)
         return v
+
+
+def _validate_single_redirect_uri(uri: str, allowed_custom: frozenset[str]) -> None:
+    parsed = urlparse(uri)
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        msg = f"Redirect URI must be an absolute URI: {uri}"
+        raise ValueError(msg)
+    # SECURITY: the denylist check MUST stay above the allowlist check below.
+    # Callers can pass ``allowed_custom_redirect_schemes`` via Pydantic context,
+    # and the endpoint's ``__init__`` guards against known-dangerous entries,
+    # but this validator is the authoritative gate — do not reorder.
+    if scheme in DISALLOWED_REDIRECT_SCHEMES:
+        msg = f"Redirect URI scheme is not allowed: {uri}"
+        raise ValueError(msg)
+    if scheme == "https":
+        if not parsed.netloc:
+            msg = f"Redirect URI must be an absolute URI: {uri}"
+            raise ValueError(msg)
+        return
+    if scheme == "http":
+        if not parsed.netloc:
+            msg = f"Redirect URI must be an absolute URI: {uri}"
+            raise ValueError(msg)
+        if parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
+            msg = f"HTTP redirect URIs are only allowed for localhost: {uri}"
+            raise ValueError(msg)
+        return
+    # Custom URI scheme (RFC 8252). Only accepted when the library caller has
+    # explicitly opted this scheme in.
+    if scheme not in allowed_custom:
+        msg = (
+            "Redirect URI must use HTTPS (or HTTP for localhost), "
+            f"or a scheme explicitly allowed by the server: {uri}"
+        )
+        raise ValueError(msg)
+    if not parsed.netloc and not parsed.path:
+        msg = f"Redirect URI must be an absolute URI: {uri}"
+        raise ValueError(msg)
 
 
 class ClientRegistrationResponse(BaseModel):

--- a/tests/auth_mcp/authorization_server/test_registration_endpoint.py
+++ b/tests/auth_mcp/authorization_server/test_registration_endpoint.py
@@ -1,6 +1,7 @@
 import json
 from http import HTTPStatus
 
+import pytest
 from starlette.testclient import TestClient
 
 from auth_mcp.authorization_server.client_store import ClientStore
@@ -46,8 +47,14 @@ class CrashingClientStore(ClientStore):
         raise RuntimeError(msg)
 
 
-def _create_client(store: ClientStore | None = None) -> TestClient:
-    endpoint = DynamicClientRegistrationEndpoint(store or MockClientStore())
+def _create_client(
+    store: ClientStore | None = None,
+    allowed_custom_redirect_schemes: tuple[str, ...] = (),
+) -> TestClient:
+    endpoint = DynamicClientRegistrationEndpoint(
+        store or MockClientStore(),
+        allowed_custom_redirect_schemes=allowed_custom_redirect_schemes,
+    )
     return TestClient(endpoint)
 
 
@@ -180,3 +187,49 @@ def test_none_fields_excluded_from_response() -> None:
     assert "client_secret" not in data
     assert "client_id_issued_at" not in data
     assert "client_secret_expires_at" not in data
+
+
+def test_custom_scheme_rejected_without_allowlist() -> None:
+    client = _create_client()
+    response = client.post(
+        "/",
+        json={"redirect_uris": ["cursor://anysphere.cursor-mcp/oauth/callback"]},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    data = response.json()
+    assert data["error"] == "invalid_client_metadata"
+
+
+def test_custom_scheme_accepted_when_allowlisted() -> None:
+    client = _create_client(allowed_custom_redirect_schemes=("cursor",))
+    response = client.post(
+        "/",
+        json={"redirect_uris": ["cursor://anysphere.cursor-mcp/oauth/callback"]},
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    data = response.json()
+    assert data["redirect_uris"] == ["cursor://anysphere.cursor-mcp/oauth/callback"]
+
+
+def test_init_rejects_disallowed_scheme_in_allowlist() -> None:
+    with pytest.raises(ValueError, match="must not include disallowed schemes"):
+        DynamicClientRegistrationEndpoint(
+            MockClientStore(),
+            allowed_custom_redirect_schemes=("cursor", "javascript"),
+        )
+
+
+def test_init_rejects_https_in_allowlist() -> None:
+    with pytest.raises(ValueError, match="must not include 'https'"):
+        DynamicClientRegistrationEndpoint(
+            MockClientStore(),
+            allowed_custom_redirect_schemes=("https",),
+        )
+
+
+def test_init_rejects_http_in_allowlist() -> None:
+    with pytest.raises(ValueError, match="must not include 'http'"):
+        DynamicClientRegistrationEndpoint(
+            MockClientStore(),
+            allowed_custom_redirect_schemes=("http",),
+        )

--- a/tests/auth_mcp/test_redirect_uri_security.py
+++ b/tests/auth_mcp/test_redirect_uri_security.py
@@ -1,0 +1,395 @@
+"""Security regression tests for redirect-URI validation.
+
+These tests codify the security invariants of the OAuth 2.1 dynamic client
+registration redirect-URI validation (RFC 7591 / RFC 8252). They guard
+against silent regressions in the denylist, localhost checks, custom-scheme
+allowlist plumbing, and exotic URI edge cases.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from pydantic import ValidationError
+from starlette.testclient import TestClient
+
+from auth_mcp.authorization_server.client_store import ClientStore
+from auth_mcp.authorization_server.registration_endpoint import (
+    DynamicClientRegistrationEndpoint,
+)
+from auth_mcp.types.registration import (
+    DISALLOWED_REDIRECT_SCHEMES,
+    ClientRegistrationRequest,
+    ClientRegistrationResponse,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _MockClientStore(ClientStore):
+    """Minimal store that echoes back the registration request."""
+
+    _counter: int = 0
+
+    async def register_client(
+        self,
+        request: ClientRegistrationRequest,
+    ) -> ClientRegistrationResponse:
+        self._counter += 1
+        return ClientRegistrationResponse(
+            client_id=f"client_{self._counter}",
+            redirect_uris=request.redirect_uris,
+            grant_types=request.grant_types,
+            response_types=request.response_types,
+            token_endpoint_auth_method=request.token_endpoint_auth_method,
+        )
+
+
+def _endpoint_client(
+    allowed_custom_redirect_schemes: tuple[str, ...] = (),
+) -> TestClient:
+    endpoint = DynamicClientRegistrationEndpoint(
+        _MockClientStore(),
+        allowed_custom_redirect_schemes=allowed_custom_redirect_schemes,
+    )
+    return TestClient(endpoint)
+
+
+def _model_validate(
+    uris: tuple[str, ...],
+    allowed: frozenset[str] | None = None,
+) -> ClientRegistrationRequest:
+    ctx = (
+        {"allowed_custom_redirect_schemes": allowed}
+        if allowed is not None
+        else None
+    )
+    return ClientRegistrationRequest.model_validate(
+        {"redirect_uris": uris},
+        context=ctx,
+    )
+
+
+# ===================================================================
+# 1. Constants / export stability
+# ===================================================================
+
+_EXPECTED_MINIMUM_DENYLIST: frozenset[str] = frozenset(
+    {
+        "javascript",
+        "data",
+        "file",
+        "vbscript",
+        "about",
+        "blob",
+        "mailto",
+        "tel",
+        "ws",
+        "wss",
+        "ftp",
+        "ftps",
+        "intent",
+        "view-source",
+    },
+)
+
+
+def test_disallowed_schemes_is_frozenset() -> None:
+    """DISALLOWED_REDIRECT_SCHEMES must be immutable (frozenset)."""
+    assert isinstance(DISALLOWED_REDIRECT_SCHEMES, frozenset)
+
+
+def test_disallowed_schemes_contains_minimum_set() -> None:
+    """Guard against accidental removal of known-dangerous schemes."""
+    missing = _EXPECTED_MINIMUM_DENYLIST - DISALLOWED_REDIRECT_SCHEMES
+    assert not missing, f"Schemes removed from denylist: {sorted(missing)}"
+
+
+# ===================================================================
+# 2. Denylist enforcement (hard invariant)
+# ===================================================================
+
+@pytest.mark.parametrize("scheme", sorted(DISALLOWED_REDIRECT_SCHEMES))
+def test_denylist_rejects_even_when_allowlisted(scheme: str) -> None:
+    """Every scheme in the denylist is rejected at validation level.
+
+    Even when the caller passes it in allowed_custom_redirect_schemes.
+    """
+    uri = f"{scheme}://anything.example.com/path"
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
+        _model_validate(
+            (uri,),
+            allowed=frozenset({scheme}),
+        )
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "JavaScript:alert(1)",
+        "JAVASCRIPT:ALERT(1)",
+        "DATA:text/html,<h1>hi</h1>",
+        "Data:text/html,<script>x</script>",
+        "Intent://evil#Intent;scheme=http;end",
+        "INTENT://evil#Intent;scheme=http;end",
+        "View-Source:https://example.com",
+        "VIEW-SOURCE:https://example.com",
+        "VbScript:MsgBox(1)",
+    ],
+    ids=[
+        "JavaScript-title",
+        "JAVASCRIPT-upper",
+        "DATA-upper",
+        "Data-mixed",
+        "Intent-title",
+        "INTENT-upper",
+        "View-Source-title",
+        "VIEW-SOURCE-upper",
+        "VbScript-mixed",
+    ],
+)
+def test_denylist_case_insensitive(uri: str) -> None:
+    """Denylist comparison is case-insensitive — mixed/upper case rejected."""
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
+        _model_validate((uri,))
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        # Whitespace around URI — urlparse strips leading whitespace from
+        # the scheme on some Python versions; trailing is part of the path.
+        "  javascript:alert(1)",
+        "javascript:alert(1)  ",
+    ],
+    ids=["leading-whitespace", "trailing-whitespace"],
+)
+def test_denylist_whitespace_variants(uri: str) -> None:
+    """URIs with surrounding whitespace are still rejected or fail.
+
+    Either outcome is safe — the URI never passes validation.
+    """
+    with pytest.raises(ValidationError):
+        _model_validate((uri,))
+
+
+# ===================================================================
+# 3. Localhost check strictness
+# ===================================================================
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://127.1/",
+        "http://0x7f000001/",
+        "http://2130706433/",
+        "http://[::ffff:127.0.0.1]/",
+        "http://0.0.0.0/",
+        "http://localhost.attacker.com/",
+        "http://attacker.com#@localhost/",
+        "http://user@localhost@attacker.com/",
+    ],
+    ids=[
+        "127.1-short",
+        "hex-ip",
+        "decimal-ip",
+        "ipv4-mapped-ipv6",
+        "0.0.0.0",  # noqa: S104
+        "localhost-subdomain",
+        "fragment-at-localhost",
+        "userinfo-bypass-attempt",
+    ],
+)
+def test_http_localhost_aliases_rejected(uri: str) -> None:
+    """HTTP redirect URIs with localhost aliases are rejected.
+
+    The validator only allows literal ``localhost``, ``127.0.0.1``,
+    and ``::1``.
+    """
+    with pytest.raises(ValidationError):
+        _model_validate((uri,))
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://localhost/",
+        "http://localhost:3000/callback",
+        "http://localhost/path?q=1",
+        "http://LOCALHOST/",
+        "http://127.0.0.1/",
+        "http://127.0.0.1:8080/callback",
+        "http://[::1]/",
+        "http://[::1]:9090/callback",
+    ],
+    ids=[
+        "localhost-bare",
+        "localhost-port",
+        "localhost-path-query",
+        "LOCALHOST-upper",
+        "127.0.0.1-bare",
+        "127.0.0.1-port",
+        "ipv6-loopback",
+        "ipv6-loopback-port",
+    ],
+)
+def test_http_localhost_valid_forms_accepted(uri: str) -> None:
+    """Canonical localhost forms are accepted for HTTP redirect URIs."""
+    result = _model_validate((uri,))
+    assert uri in result.redirect_uris
+
+
+# ===================================================================
+# 4. Allowlist plumbing — end-to-end through endpoint
+# ===================================================================
+
+def test_e2e_custom_scheme_cursor_accepted() -> None:
+    """Custom scheme accepted end-to-end when allowlisted at init."""
+    client = _endpoint_client(allowed_custom_redirect_schemes=("cursor",))
+    response = client.post(
+        "/",
+        json={
+            "redirect_uris": [
+                "cursor://anysphere.cursor-mcp/oauth/callback",
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    data = response.json()
+    assert data["redirect_uris"] == [
+        "cursor://anysphere.cursor-mcp/oauth/callback",
+    ]
+
+
+def test_e2e_reverse_dns_custom_scheme_accepted() -> None:
+    """Reverse-DNS custom scheme (RFC 8252 style) accepted."""
+    client = _endpoint_client(
+        allowed_custom_redirect_schemes=("com.example.app",),
+    )
+    response = client.post(
+        "/",
+        json={
+            "redirect_uris": [
+                "com.example.app://oauth/callback",
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    data = response.json()
+    assert data["redirect_uris"] == ["com.example.app://oauth/callback"]
+
+
+def test_e2e_custom_scheme_not_in_allowlist_rejected() -> None:
+    """Custom scheme NOT in the allowlist is rejected with helpful msg."""
+    client = _endpoint_client(allowed_custom_redirect_schemes=("cursor",))
+    response = client.post(
+        "/",
+        json={
+            "redirect_uris": [
+                "vscode://ms-vscode.mcp/oauth/callback",
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    data = response.json()
+    assert "explicitly allowed by the server" in data["error_description"]
+
+
+def test_endpoint_init_rejects_disallowed_scheme_case_insensitive() -> None:
+    """Endpoint __init__ rejects a denylist scheme regardless of case."""
+    with pytest.raises(ValueError, match="must not include disallowed"):
+        DynamicClientRegistrationEndpoint(
+            _MockClientStore(),
+            allowed_custom_redirect_schemes=("INTENT",),
+        )
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    ["HTTP", "Http", "http", "HTTPS", "Https", "https"],
+    ids=str,
+)
+def test_endpoint_init_rejects_http_https_any_case(
+    reserved: str,
+) -> None:
+    """Endpoint __init__ rejects http/https in allowlist (any case)."""
+    with pytest.raises(ValueError, match="must not include"):
+        DynamicClientRegistrationEndpoint(
+            _MockClientStore(),
+            allowed_custom_redirect_schemes=(reserved,),
+        )
+
+
+# ===================================================================
+# 5. Exotic URI shapes
+# ===================================================================
+
+def test_empty_redirect_uri_rejected() -> None:
+    with pytest.raises(ValidationError, match="must be an absolute URI"):
+        _model_validate(("",))
+
+
+def test_relative_uri_rejected() -> None:
+    with pytest.raises(ValidationError, match="must be an absolute URI"):
+        _model_validate(("/callback",))
+
+
+def test_scheme_only_uri_rejected_for_custom_scheme() -> None:
+    """A URI with only a scheme (no netloc, no path) is rejected."""
+    with pytest.raises(ValidationError, match="must be an absolute URI"):
+        _model_validate(("cursor:",), allowed=frozenset({"cursor"}))
+
+
+def test_query_and_fragment_preserved_on_success() -> None:
+    """Query and fragment in valid HTTPS URIs survive validation."""
+    uri = "https://c.example.com/cb?x=1#y=2"
+    result = _model_validate((uri,))
+    assert result.redirect_uris == (uri,)
+
+
+def test_mixed_valid_and_invalid_uris_all_rejected() -> None:
+    """One invalid URI in the tuple causes the whole list to fail."""
+    with pytest.raises(ValidationError):
+        _model_validate((
+            "https://good.example.com/callback",
+            "javascript:alert(1)",
+        ))
+
+
+def test_crlf_injection_uri_rejected_or_safe_json() -> None:
+    """URI with embedded CR/LF is rejected or serialized safely.
+
+    Even if somehow accepted, JSON serialization escapes control chars,
+    so header injection via the error body is not possible.
+    """
+    uri = "https://example.com/\r\nInjected-Header: x"
+    client = _endpoint_client()
+    response = client.post("/", json={"redirect_uris": [uri]})
+    # The response MUST be valid JSON regardless.
+    data = response.json()
+    assert isinstance(data, dict)
+    # If the server rejected it (most likely), verify error shape.
+    if response.status_code != HTTPStatus.CREATED:
+        assert data["error"] == "invalid_client_metadata"
+    # Confirm the raw body does not contain bare CRLF that could split
+    # HTTP headers (the JSON encoder escapes \r\n).
+    assert b"\r\nInjected-Header" not in response.content
+
+
+# ===================================================================
+# 6. Denylist at endpoint level (integration)
+# ===================================================================
+
+@pytest.mark.parametrize("scheme", sorted(DISALLOWED_REDIRECT_SCHEMES))
+def test_e2e_denylist_rejected_through_endpoint(scheme: str) -> None:
+    """Every denylist scheme is rejected through the full endpoint stack."""
+    client = _endpoint_client()
+    response = client.post(
+        "/",
+        json={"redirect_uris": [f"{scheme}://evil.example.com/x"]},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    data = response.json()
+    assert data["error"] == "invalid_client_metadata"

--- a/tests/auth_mcp/types/test_registration.py
+++ b/tests/auth_mcp/types/test_registration.py
@@ -59,21 +59,21 @@ def test_client_registration_request_rejects_http_non_localhost() -> None:
 
 
 def test_client_registration_request_rejects_javascript_uri() -> None:
-    with pytest.raises(ValidationError, match="must be an absolute URI"):
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
         ClientRegistrationRequest(
             redirect_uris=("javascript:alert(1)",),
         )
 
 
 def test_client_registration_request_rejects_data_uri() -> None:
-    with pytest.raises(ValidationError, match="must be an absolute URI"):
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
         ClientRegistrationRequest(
             redirect_uris=("data:text/html,<script>alert(1)</script>",),
         )
 
 
 def test_client_registration_request_rejects_ftp_scheme() -> None:
-    with pytest.raises(ValidationError, match="must use HTTPS"):
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
         ClientRegistrationRequest(
             redirect_uris=("ftp://files.example.com/callback",),
         )
@@ -83,6 +83,42 @@ def test_client_registration_request_rejects_relative_uri() -> None:
     with pytest.raises(ValidationError, match="must be an absolute URI"):
         ClientRegistrationRequest(
             redirect_uris=("/callback",),
+        )
+
+
+def test_client_registration_request_rejects_unlisted_custom_scheme() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=r"must use HTTPS .* or a scheme explicitly allowed by the server",
+    ):
+        ClientRegistrationRequest(
+            redirect_uris=("cursor://anysphere.cursor-mcp/oauth/callback",),
+        )
+
+
+def test_client_registration_request_allows_listed_custom_scheme() -> None:
+    request = ClientRegistrationRequest.model_validate(
+        {"redirect_uris": ("cursor://anysphere.cursor-mcp/oauth/callback",)},
+        context={"allowed_custom_redirect_schemes": frozenset({"cursor"})},
+    )
+    assert request.redirect_uris == ("cursor://anysphere.cursor-mcp/oauth/callback",)
+
+
+def test_client_registration_request_allows_listed_custom_scheme_case_insensitive() -> None:
+    request = ClientRegistrationRequest.model_validate(
+        {"redirect_uris": ("Cursor://anysphere.cursor-mcp/oauth/callback",)},
+        context={"allowed_custom_redirect_schemes": frozenset({"CURSOR"})},
+    )
+    assert request.redirect_uris == ("Cursor://anysphere.cursor-mcp/oauth/callback",)
+
+
+def test_client_registration_request_disallowed_scheme_not_bypassable_by_allowlist() -> None:
+    # Even if a caller mistakenly allows ``javascript``, the hard denylist
+    # still rejects the URI at the Pydantic level.
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
+        ClientRegistrationRequest.model_validate(
+            {"redirect_uris": ("javascript:alert(1)",)},
+            context={"allowed_custom_redirect_schemes": frozenset({"javascript"})},
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "http-mcp"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -192,7 +192,7 @@ dev = [
     { name = "jsonschema", specifier = ">=4.26.0,<5.0.0" },
     { name = "mdformat", specifier = ">=1.0.0,<2.0.0" },
     { name = "mypy", specifier = ">=1.19.1,<2.0.0" },
-    { name = "pytest", specifier = ">=9.0.2,<10.0.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
     { name = "ruff", specifier = ">=0.15.2,<0.16.0" },
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -549,9 +549,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds allowed_custom_redirect_schemes to ProtectedMCPAppConfig and DynamicClientRegistrationEndpoint, enabling RFC 8252 native-app redirect URIs (e.g. cursor://anysphere.cursor-mcp/oauth/callback) to pass dynamic client registration when the library user explicitly opts the scheme in. A hard denylist (DISALLOWED_REDIRECT_SCHEMES) blocks javascript/data/file/intent/view-source/etc. and cannot be bypassed via the allowlist. Adds security regression tests covering denylist enforcement, localhost alias rejection, allowlist plumbing, and exotic URI shapes. Bumps version to 0.13.0.