### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sca-scan.yml
+++ b/.github/workflows/sca-scan.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches-ignore: [main]
 
+permissions:
+  contents: read
+
 jobs:
   sca-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/yeison-liscano/http_mcp/security/code-scanning/2](https://github.com/yeison-liscano/http_mcp/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal required access unless overridden.  
For this workflow, the best non-breaking default is:

- `contents: read`

This supports `actions/checkout` and keeps token privileges constrained.  
Change `.github/workflows/sca-scan.yml` right after the `on` section and before `jobs`.

No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
