### PR TITLE
fix: correct transport error handling and MCP spec compliance, bump t…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
-version = "0.13.1"
+version = "0.14.0"
 
 dependencies = ["pydantic (>=2.12.5,<3.0.0)", "uvicorn (>=0.41.0,<0.42.0)", "starlette>=0.52.1,<1.4.0"]
 

--- a/src/auth_mcp/resource_server/integration.py
+++ b/src/auth_mcp/resource_server/integration.py
@@ -51,6 +51,7 @@ def _get_registration_endpoint_path(
         return config.authorization_server_metadata.registration_endpoint.path or "/register"
     return "/register"
 
+
 def create_protected_mcp_app(
     config: ProtectedMCPAppConfig,
     **starlette_kwargs: object,
@@ -109,7 +110,6 @@ def create_protected_mcp_app(
         registration_path = _get_registration_endpoint_path(config)
         routes.append(Route(registration_path, registration_endpoint))
 
-
     routes.append(
         Mount(
             config.mcp_path,
@@ -122,14 +122,13 @@ def create_protected_mcp_app(
                 ),
                 Middleware(
                     AuthenticationMiddleware,
-                        backend=OAuthAuthenticationBackend(
+                    backend=OAuthAuthenticationBackend(
                         token_validator=config.token_validator,
                         resource_uri=str(config.resource_endpoint.resource),
                         require_authentication=config.require_authentication,
                     ),
                     on_error=on_auth_error,
                 ),
-                *config.middlewares,
             ],
         ),
     )

--- a/src/http_mcp/_json_rcp_types/errors.py
+++ b/src/http_mcp/_json_rcp_types/errors.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, computed_field
 
 
 class ErrorCode(IntEnum):
+    INVALID_REQUEST = -32600
     INVALID_PARAMS = -32602
     INTERNAL_ERROR = -32603
     METHOD_NOT_FOUND = -32601
@@ -15,7 +16,7 @@ class Error(BaseModel):
     description: str | None = Field(default=None, exclude=True)
     data: dict | None = Field(default=None)
 
-    @computed_field # type: ignore[prop-decorator]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def message(self) -> str:
         if self.description:

--- a/src/http_mcp/_mcp_types/prompts.py
+++ b/src/http_mcp/_mcp_types/prompts.py
@@ -8,7 +8,8 @@ from http_mcp._mcp_types.content import TextContent
 
 class PromptGetRequestParams(BaseModel):
     name: str
-    arguments: dict
+    # Optional per the MCP specification: omitted for prompts that take no arguments.
+    arguments: dict = Field(default_factory=dict)
 
 
 class PromptGetRequest(JSONRPCRequest):

--- a/src/http_mcp/_mcp_types/tools.py
+++ b/src/http_mcp/_mcp_types/tools.py
@@ -35,7 +35,8 @@ class ToolsCallResponse(JSONRPCMessage):
 
 class ToolsCallRequestParams(BaseModel):
     name: str
-    arguments: dict[str, Any]
+    # Optional per the MCP specification: omitted for tools that take no arguments.
+    arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 class ToolsCallRequest(JSONRPCRequest):
@@ -51,14 +52,17 @@ class ToolsListRequestParams(BaseModel):
     def validate_cursor(cls, v: object) -> int | None:
         if v is None:
             return None
-        if isinstance(v, bool):
-            return None
-        if isinstance(v, int | str | bytes):
-            try:
-                return int(v)
-            except (ValueError, TypeError):
-                return None
-        return None
+        invalid_cursor_msg = "Invalid cursor"
+        if isinstance(v, bool) or not isinstance(v, int | str):
+            # ValueError (not TypeError) so pydantic reports it as a validation error
+            raise ValueError(invalid_cursor_msg)  # noqa: TRY004
+        try:
+            cursor = int(v)
+        except ValueError as e:
+            raise ValueError(invalid_cursor_msg) from e
+        if cursor < 0:
+            raise ValueError(invalid_cursor_msg)
+        return cursor
 
 
 class ToolsListRequest(JSONRPCRequest):

--- a/src/http_mcp/_stdio_transport.py
+++ b/src/http_mcp/_stdio_transport.py
@@ -28,6 +28,18 @@ MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024  # 4MB, matching HTTP transport
 _MAX_LOG_LENGTH = 500
 
 
+def _is_notification(json_message: object) -> bool:
+    """Return True for JSON-RPC notifications, which must not receive a response."""
+    if not isinstance(json_message, dict):
+        return False
+    method = json_message.get("method")
+    return (
+        isinstance(method, str)
+        and method.startswith("notifications/")
+        and json_message.get("id") is None
+    )
+
+
 class StdioTransport(BaseTransport):
     def __init__(self, server: ServerInterface) -> None:
         super().__init__(server)
@@ -74,9 +86,10 @@ class StdioTransport(BaseTransport):
                 continue
 
             LOGGER.debug("Received message: %s", line[:_MAX_LOG_LENGTH])
-            json_message = {}
             try:
                 json_message = json.loads(line)
+                if _is_notification(json_message):
+                    continue
                 await self._handle_message(
                     JSONRPCRequest.model_validate(json_message),
                     writer,
@@ -143,11 +156,8 @@ class StdioTransport(BaseTransport):
         dummy_request = Request(scope)
 
         async def process(msg: JSONRPCRequest) -> JSONRPCMessage | JSONRPCError | None:
-            if msg.method.startswith("notifications/"):
-                return None
-
             try:
-                return await self._process_request(msg, dummy_request)
+                response, _ = await self._process_request(msg, dummy_request)
             except InsufficientScopeError as e:
                 required = " ".join(e.required_scopes) if e.required_scopes else "unknown"
                 return JSONRPCError(
@@ -168,6 +178,8 @@ class StdioTransport(BaseTransport):
                         description="Internal server error",
                     ),
                 )
+            else:
+                return response
 
         response = await process(message)
         if response:

--- a/src/http_mcp/_transport_base.py
+++ b/src/http_mcp/_transport_base.py
@@ -53,7 +53,12 @@ class _PingResult(BaseModel):
 class BaseTransport:
     supported_versions = ("2025-03-26", "2025-06-18", "2025-11-25")
     supported_methods = (
-        "initialize", "ping", "tools/list", "tools/call", "prompts/list", "prompts/get",
+        "initialize",
+        "ping",
+        "tools/list",
+        "tools/call",
+        "prompts/list",
+        "prompts/get",
     )
 
     def __init__(self, server: ServerInterface) -> None:
@@ -63,21 +68,32 @@ class BaseTransport:
         self,
         message: JSONRPCRequest,
         request: Request,
-    ) -> JSONRPCMessage:
+    ) -> tuple[JSONRPCMessage, HTTPStatus]:
         if message.method == "ping":
-            return JSONRPCResponse(jsonrpc="2.0", id=message.id, result=_PingResult())
+            ping_response = JSONRPCResponse(jsonrpc="2.0", id=message.id, result=_PingResult())
+            return ping_response, HTTPStatus.OK
         if message.method == "initialize":
-            response, _ = self._handle_initialization(message)
-            return response
+            return self._handle_initialization(message)
         if message.method.startswith("tools/"):
-            return await self._process_tools_request(message, request)
+            return await self._process_tools_request(message, request), HTTPStatus.OK
+        if message.method.startswith("prompts/"):
+            return await self._process_prompts_request(message, request), HTTPStatus.OK
 
-        return await self._process_prompts_request(message, request)
+        # Remaining validated methods (e.g. notification methods sent with an id)
+        # are not callable request methods.
+        return JSONRPCError(
+            jsonrpc="2.0",
+            id=message.id,
+            error=Error(
+                code=ErrorCode.METHOD_NOT_FOUND,
+                description=f"Method not supported: {message.method}",
+            ),
+        ), HTTPStatus.BAD_REQUEST
 
     def _handle_initialization(
         self,
         message: JSONRPCRequest,
-    ) -> tuple[InitializeResponse | JSONRPCError, int]:
+    ) -> tuple[InitializeResponse | JSONRPCError, HTTPStatus]:
         try:
             message = InitializationRequest.model_validate(message.model_dump())
         except ValidationError as e:
@@ -145,6 +161,18 @@ class BaseTransport:
 
         try:
             validated_message = PromptGetRequest.model_validate(message.model_dump())
+        except ValidationError as e:
+            LOGGER.exception("Prompt get validation error")
+            return JSONRPCError(
+                jsonrpc="2.0",
+                id=message.id,
+                error=Error(
+                    code=ErrorCode.INVALID_PARAMS,
+                    description=sanitize_validation_errors(e),
+                ),
+            )
+
+        try:
             prompt_result = await self._server.get_prompt(
                 validated_message.params.name,
                 validated_message.params.arguments,

--- a/src/http_mcp/_transport_http.py
+++ b/src/http_mcp/_transport_http.py
@@ -81,32 +81,47 @@ class HTTPTransport(BaseTransport):
 
     async def _handle_raw_message(
         self,
-        raw_message: dict,
+        raw_message: object,
         send: Send,
         request: Request,
     ) -> None:
+        if not isinstance(raw_message, dict):
+            LOGGER.error("Invalid request: body is not a JSON object")
+            await self._send_error_response(
+                send,
+                ErrorResponseInfo(
+                    protocol_code=ErrorCode.INVALID_REQUEST,
+                    http_status_code=HTTPStatus.BAD_REQUEST,
+                    message="Invalid Request: body must be a single JSON-RPC request object",
+                ),
+            )
+            return None
+
+        method = raw_message.get("method")
+        is_notification = (
+            isinstance(method, str)
+            and method.startswith("notifications/")
+            and raw_message.get("id") is None
+        )
+        if is_notification:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": HTTPStatus.ACCEPTED.value,
+                    "headers": [*_SECURITY_HEADERS],
+                },
+            )
+
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"",
+                    "more_body": False,
+                },
+            )
+            return None
+
         try:
-            if raw_message.get("method", "").startswith("notifications/"):
-                await send(
-                    {
-                        "type": "http.response.start",
-                        "status": 200,
-                        "headers": [
-                            (b"content-type", b"application/json"),
-                            *_SECURITY_HEADERS,
-                        ],
-                    },
-                )
-
-                await send(
-                    {
-                        "type": "http.response.body",
-                        "body": b"",
-                        "more_body": False,
-                    },
-                )
-                return None
-
             request_message = JSONRPCRequest.model_validate(raw_message)
         except ValidationError:
             LOGGER.exception("Error validating message")
@@ -135,7 +150,7 @@ class HTTPTransport(BaseTransport):
         request: Request,
     ) -> None:
         try:
-            response = await self._process_request(message, request)
+            response, status_code = await self._process_request(message, request)
         except InsufficientScopeError:
             await self._send_forbidden_response(send)
             return
@@ -155,7 +170,7 @@ class HTTPTransport(BaseTransport):
         await send(
             {
                 "type": "http.response.start",
-                "status": HTTPStatus.OK.value,
+                "status": status_code.value,
                 "headers": [
                     (b"content-type", b"application/json"),
                     *_SECURITY_HEADERS,

--- a/src/http_mcp/server.py
+++ b/src/http_mcp/server.py
@@ -12,6 +12,26 @@ from http_mcp.server_interface import ServerInterface
 from http_mcp.types import Prompt, Tool
 
 
+def _check_scope(request: Request, scopes: tuple[str, ...]) -> bool:
+    """Check scopes, failing closed when no authentication backend is installed.
+
+    Scoped tools/prompts are hidden and denied instead of raising when
+    AuthenticationMiddleware is missing (e.g. STDIO transport).
+    """
+    if not scopes:
+        return True
+    if "auth" not in request.scope:
+        return False
+    return has_required_scope(request, scopes)
+
+
+def _ensure_unique_names(feature_type: str, names: tuple[str, ...]) -> None:
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        msg = f"Duplicate {feature_type} names are not allowed: {duplicates}"
+        raise ValueError(msg)
+
+
 class MCPServer(ServerInterface):
     def __init__(
         self,
@@ -21,6 +41,8 @@ class MCPServer(ServerInterface):
         prompts: tuple[Prompt, ...] = (),
         instructions: str | None = None,
     ) -> None:
+        _ensure_unique_names("tool", tuple(_tool.name for _tool in tools))
+        _ensure_unique_names("prompt", tuple(_prompt.name for _prompt in prompts))
         self._version = version
         self._name = name
         self._tools = tools
@@ -59,7 +81,7 @@ class MCPServer(ServerInterface):
         return tuple(
             _tool.generate_json_schema()
             for _tool in self._tools
-            if has_required_scope(request, _tool.scopes)
+            if _check_scope(request, _tool.scopes)
         )
 
     async def call_tool(
@@ -72,7 +94,7 @@ class MCPServer(ServerInterface):
             tool = next(_tool for _tool in self._tools if _tool.name == tool_name)
         except StopIteration as e:
             raise ToolNotFoundError(tool_name) from e
-        if not has_required_scope(request, tool.scopes):
+        if not _check_scope(request, tool.scopes):
             raise InsufficientScopeError(tool.scopes)
 
         return await tool.invoke(args, request)
@@ -82,7 +104,7 @@ class MCPServer(ServerInterface):
             prompts=tuple(
                 _prompt.to_prompt_protocol_object()
                 for _prompt in self._prompts
-                if has_required_scope(request, _prompt.scopes)
+                if _check_scope(request, _prompt.scopes)
             ),
             next_cursor=None,
         )
@@ -97,7 +119,7 @@ class MCPServer(ServerInterface):
             _prompt = next(_prompt for _prompt in self._prompts if _prompt.name == prompt_name)
         except StopIteration as e:
             raise PromptNotFoundError(prompt_name) from e
-        if not has_required_scope(request, _prompt.scopes):
+        if not _check_scope(request, _prompt.scopes):
             raise InsufficientScopeError(_prompt.scopes)
 
         result = await _prompt.invoke(arguments, request)

--- a/src/http_mcp/types/tools.py
+++ b/src/http_mcp/types/tools.py
@@ -158,5 +158,4 @@ class Tool[TInputs: BaseModel | None, TOutput: BaseModel]:
             "inputSchema": self.input_schema,
             "outputSchema": self.output_schema,
             "annotations": self.annotations,
-            "meta": None,
         }

--- a/tests/auth_mcp/resource_server/test_authentication_backend.py
+++ b/tests/auth_mcp/resource_server/test_authentication_backend.py
@@ -40,9 +40,7 @@ def _make_connection(headers: dict[str, str] | None = None) -> HTTPConnection:
         "type": "http",
         "method": "POST",
         "path": "/mcp",
-        "headers": [
-            (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
-        ],
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
     }
     return HTTPConnection(scope)
 

--- a/tests/auth_mcp/resource_server/test_integration.py
+++ b/tests/auth_mcp/resource_server/test_integration.py
@@ -1,8 +1,10 @@
+import typing as t
 from http import HTTPStatus
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from auth_mcp.authorization_server.client_store import ClientStore
 from auth_mcp.resource_server.integration import (
@@ -301,9 +303,7 @@ def test_no_client_store_returns_404() -> None:
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
-_EXPECTED_METADATA_URL = (
-    "https://mcp.example.com/.well-known/oauth-protected-resource/mcp/"
-)
+_EXPECTED_METADATA_URL = "https://mcp.example.com/.well-known/oauth-protected-resource/mcp/"
 
 
 def test_www_authenticate_resource_metadata_is_absolute_url_on_401() -> None:
@@ -354,10 +354,7 @@ def test_www_authenticate_resource_metadata_uses_origin_only() -> None:
     )
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     www_auth = response.headers["www-authenticate"]
-    expected = (
-        "https://api.example.com"
-        "/.well-known/oauth-protected-resource/mcp/"
-    )
+    expected = "https://api.example.com/.well-known/oauth-protected-resource/mcp/"
     assert f'resource_metadata="{expected}"' in www_auth
 
 
@@ -380,11 +377,9 @@ def test_www_authenticate_resource_metadata_port_included_when_present() -> None
     )
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     www_auth = response.headers["www-authenticate"]
-    expected = (
-        "http://localhost:8443"
-        "/.well-known/oauth-protected-resource/mcp/"
-    )
+    expected = "http://localhost:8443/.well-known/oauth-protected-resource/mcp/"
     assert f'resource_metadata="{expected}"' in www_auth
+
 
 def test_full_discovery_flow() -> None:
     server = MCPServer(name="test-flow", version="1.0.0", tools=_TOOLS)
@@ -413,3 +408,39 @@ def test_full_discovery_flow() -> None:
     )
     assert reg_response.status_code == HTTPStatus.CREATED
     assert "client_id" in reg_response.json()
+
+
+class _CountingMiddleware:
+    """ASGI middleware that counts how many times it processes a request."""
+
+    call_counts: t.ClassVar[list[str]] = []
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            self.call_counts.append(scope["path"])
+        await self._app(scope, receive, send)
+
+
+def test_custom_middlewares_run_once_per_request() -> None:
+    _CountingMiddleware.call_counts.clear()
+    server = MCPServer(name="test-middleware", version="1.0.0", tools=_TOOLS)
+    config = ProtectedMCPAppConfig(
+        mcp_server=server,
+        token_validator=MockTokenValidator(),
+        resource_endpoint=ProtectedResourceMetadata(
+            resource="https://mcp.example.com",
+            authorization_servers=("https://auth.example.com",),
+        ),
+        require_authentication=False,
+        middlewares=(Middleware(_CountingMiddleware),),
+    )
+    client = TestClient(create_protected_mcp_app(config))
+    response = client.post(
+        "/mcp/",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1, "params": {}},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert _CountingMiddleware.call_counts == ["/mcp/"]

--- a/tests/auth_mcp/test_redirect_uri_security.py
+++ b/tests/auth_mcp/test_redirect_uri_security.py
@@ -28,6 +28,7 @@ from auth_mcp.types.registration import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 class _MockClientStore(ClientStore):
     """Minimal store that echoes back the registration request."""
 
@@ -61,11 +62,7 @@ def _model_validate(
     uris: tuple[str, ...],
     allowed: frozenset[str] | None = None,
 ) -> ClientRegistrationRequest:
-    ctx = (
-        {"allowed_custom_redirect_schemes": allowed}
-        if allowed is not None
-        else None
-    )
+    ctx = {"allowed_custom_redirect_schemes": allowed} if allowed is not None else None
     return ClientRegistrationRequest.model_validate(
         {"redirect_uris": uris},
         context=ctx,
@@ -110,6 +107,7 @@ def test_disallowed_schemes_contains_minimum_set() -> None:
 # ===================================================================
 # 2. Denylist enforcement (hard invariant)
 # ===================================================================
+
 
 @pytest.mark.parametrize("scheme", sorted(DISALLOWED_REDIRECT_SCHEMES))
 def test_denylist_rejects_even_when_allowlisted(scheme: str) -> None:
@@ -179,6 +177,7 @@ def test_denylist_whitespace_variants(uri: str) -> None:
 # 3. Localhost check strictness
 # ===================================================================
 
+
 @pytest.mark.parametrize(
     "uri",
     [
@@ -244,6 +243,7 @@ def test_http_localhost_valid_forms_accepted(uri: str) -> None:
 # ===================================================================
 # 4. Allowlist plumbing — end-to-end through endpoint
 # ===================================================================
+
 
 def test_e2e_custom_scheme_cursor_accepted() -> None:
     """Custom scheme accepted end-to-end when allowlisted at init."""
@@ -326,6 +326,7 @@ def test_endpoint_init_rejects_http_https_any_case(
 # 5. Exotic URI shapes
 # ===================================================================
 
+
 def test_empty_redirect_uri_rejected() -> None:
     with pytest.raises(ValidationError, match="must be an absolute URI"):
         _model_validate(("",))
@@ -352,10 +353,12 @@ def test_query_and_fragment_preserved_on_success() -> None:
 def test_mixed_valid_and_invalid_uris_all_rejected() -> None:
     """One invalid URI in the tuple causes the whole list to fail."""
     with pytest.raises(ValidationError):
-        _model_validate((
-            "https://good.example.com/callback",
-            "javascript:alert(1)",
-        ))
+        _model_validate(
+            (
+                "https://good.example.com/callback",
+                "javascript:alert(1)",
+            ),
+        )
 
 
 def test_crlf_injection_uri_rejected_or_safe_json() -> None:
@@ -381,6 +384,7 @@ def test_crlf_injection_uri_rejected_or_safe_json() -> None:
 # ===================================================================
 # 6. Denylist at endpoint level (integration)
 # ===================================================================
+
 
 @pytest.mark.parametrize("scheme", sorted(DISALLOWED_REDIRECT_SCHEMES))
 def test_e2e_denylist_rejected_through_endpoint(scheme: str) -> None:

--- a/tests/http_mcp/_mcp_types/test_tools.py
+++ b/tests/http_mcp/_mcp_types/test_tools.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from http_mcp._mcp_types.tools import ToolsListRequestParams
 
@@ -12,15 +13,6 @@ from http_mcp._mcp_types.tools import ToolsListRequestParams
         (42, 42),
         ("5", 5),
         ("0", 0),
-        (b"10", 10),
-        (b"0", 0),
-        ("not_a_number", None),
-        (b"not_a_number", None),
-        ("", None),
-        (3.14, None),
-        ([], None),
-        ({}, None),
-        (True, None),
     ],
     ids=[
         "none",
@@ -29,17 +21,40 @@ from http_mcp._mcp_types.tools import ToolsListRequestParams
         "int_large",
         "str_valid",
         "str_zero",
-        "bytes_valid",
-        "bytes_zero",
+    ],
+)
+def test_validate_cursor(input_value: object, expected: int | None) -> None:
+    params = ToolsListRequestParams(cursor=input_value)  # type: ignore[arg-type]
+    assert params.cursor == expected
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "not_a_number",
+        b"10",
+        b"not_a_number",
+        "",
+        3.14,
+        [],
+        {},
+        True,
+        -1,
+        "-5",
+    ],
+    ids=[
         "str_invalid",
+        "bytes",
         "bytes_invalid",
         "str_empty",
         "float",
         "list",
         "dict",
         "bool",
+        "int_negative",
+        "str_negative",
     ],
 )
-def test_validate_cursor(input_value: object, expected: int | None) -> None:
-    params = ToolsListRequestParams(cursor=input_value)  # type: ignore[arg-type]
-    assert params.cursor == expected
+def test_validate_cursor_invalid(input_value: object) -> None:
+    with pytest.raises(ValidationError, match="Invalid cursor"):
+        ToolsListRequestParams(cursor=input_value)  # type: ignore[arg-type]

--- a/tests/http_mcp/test_prompts.py
+++ b/tests/http_mcp/test_prompts.py
@@ -496,9 +496,7 @@ def test_prompt_without_args_reraises_server_error() -> None:
     server = MCPServer(
         name="test",
         version="1.0.0",
-        prompts=(
-            Prompt(func=prompt_raising_server_error, arguments_type=type(None)),
-        ),
+        prompts=(Prompt(func=prompt_raising_server_error, arguments_type=type(None)),),
     )
     client = TestClient(server.app)
     response = client.post(
@@ -527,9 +525,7 @@ def test_prompt_with_args_reraises_server_error() -> None:
     server = MCPServer(
         name="test",
         version="1.0.0",
-        prompts=(
-            Prompt(func=prompt_raising_server_error, arguments_type=NoArguments),
-        ),
+        prompts=(Prompt(func=prompt_raising_server_error, arguments_type=NoArguments),),
     )
     client = TestClient(server.app)
     response = client.post(

--- a/tests/http_mcp/test_server.py
+++ b/tests/http_mcp/test_server.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 
+import pytest
 from starlette.testclient import TestClient
 
 from http_mcp.server import MCPServer
@@ -291,7 +292,6 @@ def test_server_list_tools() -> None:
                         "idempotentHint": True,
                         "openWorldHint": True,
                     },
-                    "meta": None,
                 },
             ],
         },
@@ -329,3 +329,51 @@ def test_server_call_tool_without_context() -> None:
             "isError": False,
         },
     }
+
+
+def test_server_rejects_duplicate_tool_names() -> None:
+    with pytest.raises(ValueError, match="Duplicate tool names"):
+        MCPServer(
+            name="test",
+            version="1.0.0",
+            tools=(*TOOLS_SIMPLE_SERVER, *TOOLS_SIMPLE_SERVER),
+        )
+
+
+def test_scoped_tools_are_hidden_without_authentication_middleware() -> None:
+    server = MCPServer(
+        name="test",
+        version="1.0.0",
+        tools=(*TOOLS_SIMPLE_SERVER, *TOOLS_SIMPLE_SERVER_WITH_SCOPES),
+    )
+    client = TestClient(server.app)
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "tools/list", "id": 1, "params": {}},
+    )
+    assert response.status_code == HTTPStatus.OK
+    tool_names = [tool["name"] for tool in response.json()["result"]["tools"]]
+    assert tool_names == ["simple_server_tool"]
+
+
+def test_scoped_tool_call_is_denied_without_authentication_middleware() -> None:
+    server = MCPServer(
+        name="test",
+        version="1.0.0",
+        tools=TOOLS_SIMPLE_SERVER_WITH_SCOPES,
+    )
+    client = TestClient(server.app)
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {
+                "name": "simple_server_tool_with_context",
+                "arguments": {"question": "What is the meaning of life?"},
+            },
+        },
+    )
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert response.json() == {"error": "insufficient_scope"}

--- a/tests/http_mcp/test_tools.py
+++ b/tests/http_mcp/test_tools.py
@@ -186,7 +186,6 @@ def test_list_tools() -> None:
                         "idempotentHint": True,
                         "openWorldHint": True,
                     },
-                    "meta": None,
                 },
                 {
                     "name": "tool_2",
@@ -228,7 +227,6 @@ def test_list_tools() -> None:
                         "idempotentHint": True,
                         "openWorldHint": True,
                     },
-                    "meta": None,
                 },
                 {
                     "name": "tool_that_raises_invocation_result",
@@ -293,7 +291,6 @@ def test_list_tools() -> None:
                         "idempotentHint": True,
                         "openWorldHint": True,
                     },
-                    "meta": None,
                 },
                 {
                     "name": "tool_without_arguments",
@@ -323,7 +320,6 @@ def test_list_tools() -> None:
                         "idempotentHint": True,
                         "openWorldHint": True,
                     },
-                    "meta": None,
                 },
                 {
                     "name": "tool_without_arguments_async",
@@ -353,7 +349,6 @@ def test_list_tools() -> None:
                         "idempotentHint": True,
                         "openWorldHint": True,
                     },
-                    "meta": None,
                 },
             ],
         },
@@ -685,9 +680,7 @@ def test_tool_without_args_reraises_server_error() -> None:
     server = MCPServer(
         name="test",
         version="1.0.0",
-        tools=(
-            Tool(func=tool_raising_server_error, inputs=type(None), output=SimpleOutput),
-        ),
+        tools=(Tool(func=tool_raising_server_error, inputs=type(None), output=SimpleOutput),),
     )
     client = TestClient(server.app)
     response = client.post(
@@ -715,9 +708,7 @@ def test_tool_with_args_reraises_server_error() -> None:
     server = MCPServer(
         name="test",
         version="1.0.0",
-        tools=(
-            Tool(func=tool_raising_server_error, inputs=NoArguments, output=SimpleOutput),
-        ),
+        tools=(Tool(func=tool_raising_server_error, inputs=NoArguments, output=SimpleOutput),),
     )
     client = TestClient(server.app)
     response = client.post(

--- a/tests/http_mcp/test_transport_base.py
+++ b/tests/http_mcp/test_transport_base.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from starlette.testclient import TestClient
 
 from http_mcp._json_rcp_types.errors import ErrorCode
+from tests.fixtures.main import mcp_server, mount_mcp_server
 from tests.fixtures.models import DUMMY_SERVER
 
 
@@ -21,7 +22,7 @@ def test_initialize_bad_request() -> None:
         },
         headers={"Content-Type": "application/json"},
     )
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.BAD_REQUEST
     assert response.json() == {
         "jsonrpc": "2.0",
         "id": 1,
@@ -60,7 +61,7 @@ def test_initialize_unsupported_version() -> None:
         },
         headers={"Content-Type": "application/json"},
     )
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.BAD_REQUEST
     assert response.json() == {
         "jsonrpc": "2.0",
         "id": 1,
@@ -116,3 +117,79 @@ def test_invalid_tool_execution_request() -> None:
             ' or instance of ToolsCallRequestParams"}]',
         },
     }
+
+
+def test_prompts_get_with_missing_params_returns_invalid_params() -> None:
+    client = TestClient(DUMMY_SERVER.app)
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 2, "method": "prompts/get"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "error": {
+            "code": ErrorCode.INVALID_PARAMS.value,
+            "message": '[{"field": "params", "message": "Input should be a valid dictionary'
+            ' or instance of PromptGetRequestParams"}]',
+        },
+    }
+
+
+def test_prompts_get_without_arguments_key_defaults_to_empty() -> None:
+    client = TestClient(mount_mcp_server(mcp_server))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "prompts/get",
+            "params": {"name": "get_advice_without_arguments"},
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert "result" in body
+    assert body["result"]["messages"]
+
+
+def test_tools_call_without_arguments_key_defaults_to_empty() -> None:
+    client = TestClient(mount_mcp_server(mcp_server))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "get_time"},
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert "result" in body
+    assert body["result"]["isError"] is False
+
+
+def test_tools_list_with_invalid_cursor_returns_invalid_params() -> None:
+    client = TestClient(DUMMY_SERVER.app)
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/list",
+            "params": {"cursor": "not_a_number"},
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["error"]["code"] == ErrorCode.INVALID_PARAMS.value

--- a/tests/http_mcp/test_transport_http.py
+++ b/tests/http_mcp/test_transport_http.py
@@ -85,7 +85,7 @@ def test_notification() -> None:
         },
         headers={"Content-Type": "application/json"},
     )
-    assert response.status_code == HTTPStatus.OK
+    assert response.status_code == HTTPStatus.ACCEPTED
     assert response.text == ""
 
 
@@ -113,5 +113,54 @@ def test_invalid_message() -> None:
         "error": {
             "code": ErrorCode.METHOD_NOT_FOUND.value,
             "message": "Error validating message request",
+        },
+    }
+
+
+def test_json_array_body_returns_invalid_request() -> None:
+    client = TestClient(DUMMY_SERVER.app)
+
+    response = client.post(
+        "/mcp",
+        json=[{"jsonrpc": "2.0", "id": 1, "method": "ping"}],
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "error": {
+            "code": ErrorCode.INVALID_REQUEST.value,
+            "message": "Invalid Request: body must be a single JSON-RPC request object",
+        },
+    }
+
+
+def test_json_scalar_body_returns_invalid_request() -> None:
+    client = TestClient(DUMMY_SERVER.app)
+
+    response = client.post(
+        "/mcp",
+        json="just a string",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["error"]["code"] == ErrorCode.INVALID_REQUEST.value
+
+
+def test_notification_method_with_id_returns_method_not_found() -> None:
+    client = TestClient(DUMMY_SERVER.app)
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 6, "method": "notifications/subscribe"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 6,
+        "error": {
+            "code": ErrorCode.METHOD_NOT_FOUND.value,
+            "message": "Method not supported: notifications/subscribe",
         },
     }

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -44,9 +44,9 @@ def test_http_list_only_public_tools() -> None:
         "id": 1,
         "result": {
             "tools": [
-                tool.generate_json_schema() # type: ignore[attr-defined]
-                for tool in sorted(TOOLS, key=lambda x: x.name) # type: ignore[attr-defined]
-                if not tool.scopes # type: ignore[attr-defined]
+                tool.generate_json_schema()  # type: ignore[attr-defined]
+                for tool in sorted(TOOLS, key=lambda x: x.name)  # type: ignore[attr-defined]
+                if not tool.scopes  # type: ignore[attr-defined]
             ],
         },
     }
@@ -65,9 +65,9 @@ def test_public_and_private_tools() -> None:
         "id": 1,
         "result": {
             "tools": [
-                tool.generate_json_schema() # type: ignore[attr-defined]
-                for tool in sorted(TOOLS, key=lambda x: x.name) # type: ignore[attr-defined]
-                if (not tool.scopes or tool.scopes == ("private",)) # type: ignore[attr-defined]
+                tool.generate_json_schema()  # type: ignore[attr-defined]
+                for tool in sorted(TOOLS, key=lambda x: x.name)  # type: ignore[attr-defined]
+                if (not tool.scopes or tool.scopes == ("private",))  # type: ignore[attr-defined]
             ],
         },
     }
@@ -86,8 +86,8 @@ def test_private_and_superuser_tools() -> None:
         "id": 1,
         "result": {
             "tools": [
-                tool.generate_json_schema() # type: ignore[attr-defined]
-                for tool in sorted(TOOLS, key=lambda x: x.name) # type: ignore[attr-defined]
+                tool.generate_json_schema()  # type: ignore[attr-defined]
+                for tool in sorted(TOOLS, key=lambda x: x.name)  # type: ignore[attr-defined]
             ],
         },
     }

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "http-mcp"
-version = "0.13.1"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
…o 0.14.0

Bug fixes:
- Return JSON-RPC -32600 for non-object bodies instead of crashing with an unhandled AttributeError (bare 500)
- Return -32602 for invalid prompts/get params instead of a 500 internal error (ValidationError was not caught)
- Send the computed 400 status for invalid/unsupported initialize requests instead of discarding it and always replying 200
- Apply config.middlewares once (app level) in create_protected_mcp_app; they previously also ran on the MCP mount, executing twice per request
- Fail closed on scoped tools/prompts when AuthenticationMiddleware is absent (hidden from listings, 403 on call) instead of raising an AssertionError; makes scoped features behave sanely over STDIO
- Reject duplicate tool/prompt names at MCPServer construction

Spec compliance:
- Make "arguments" optional in tools/call and prompts/get params
- Return 202 Accepted with no body for notifications (was 200 with content-type: application/json and an empty body)
- Treat notification-namespace messages carrying an id as requests (-32601) and skip unknown notifications over STDIO without replying
- Reject invalid pagination cursors with -32602 instead of silently restarting from page 0
- Drop the non-spec "meta": null key from tool schemas